### PR TITLE
Simplify the resolver interface

### DIFF
--- a/src/__tests__/resolvers.js
+++ b/src/__tests__/resolvers.js
@@ -23,6 +23,7 @@ const retrieveUser = createResolver({
         }
         return true;
     },
+    mask: (obj, { id }) => [{ userId: id }],
     transform: user => ({ items: [user] }),
 });
 

--- a/src/__tests__/resources.js
+++ b/src/__tests__/resources.js
@@ -5,7 +5,7 @@ import {
     GraphQLString,
 } from 'graphql';
 
-import { getContainer } from '@globality/nodule-config';
+import { getResolver } from 'index';
 
 
 export const CompanyType = new GraphQLObjectType({
@@ -31,12 +31,7 @@ export const UserType = new GraphQLObjectType({
         },
         companyName: {
             type: GraphQLString,
-            resolve: (user, args, context) => {
-                const { resolvers } = getContainer('graphql');
-                return resolvers.company.name.retrieve({
-                    companyId: user.companyId,
-                }, context);
-            },
+            resolve: getResolver('company.name.retrieve'),
         },
         firstName: {
             type: GraphQLString,
@@ -69,11 +64,6 @@ export const User = {
                 type: GraphQLID,
             },
         },
-        resolve: (rootValue, args, context) => {
-            const { resolvers } = getContainer('graphql');
-            return resolvers.user.retrieve({
-                userId: args.id,
-            }, context);
-        },
+        resolve: getResolver('user.retrieve'),
     },
 };

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -47,7 +47,7 @@ describe('routes', () => {
         });
     });
 
-    it('handles errors', async () => {
+    it('handles not found errors', async () => {
         const app = createApp();
         const query = `
           query example {
@@ -80,7 +80,7 @@ describe('routes', () => {
         ]);
     });
 
-    it('handles errors', async () => {
+    it('handles forbidden errors', async () => {
         const app = createApp();
 
         const query = `

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ export {
     NotFound,
     UnprocessableEntity,
 } from './errors';
-export { createResolver } from './resolver';
+export { createResolver, getResolver } from './resolver';
 export { wrapResolvers } from './wrapper';


### PR DESCRIPTION
The resolver interface now matches GraphQL's, but takes a `mask` function so
we can introduce simpler semantics.