### PR TITLE
Improve OpenAPI mocking

### DIFF
--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -5,6 +5,8 @@ import { createOpenAPIClient, mockError, mockResponse } from 'index';
 
 
 describe('createOpenAPIClient', () => {
+    const req = {};
+
     const REX = {
         id: '1',
         name: 'Rex',
@@ -25,11 +27,31 @@ describe('createOpenAPIClient', () => {
 
         const client = createOpenAPIClient('petstore', spec);
 
-        const result = await client.pet.search();
+        const result = await client.pet.search(req);
         expect(result).toEqual({
             items: [
                 REX,
             ],
+        });
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+        expect(config.clients.mock.petstore.pet.search.mock.calls[0][0].headers).toMatchObject({
+            Accept: 'application/json, text/plain, */*',
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'test',
+        });
+    });
+
+    it('supports mocking a response with a function', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', () => ({ items: [] })),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        const result = await client.pet.search(req);
+        expect(result).toEqual({
+            items: [],
         });
 
         expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
@@ -47,7 +69,7 @@ describe('createOpenAPIClient', () => {
 
         const client = createOpenAPIClient('petstore', spec);
 
-        await expect(client.pet.search()).rejects.toThrow(
+        await expect(client.pet.search(req)).rejects.toThrow(
             'Not Found',
         );
 
@@ -57,8 +79,26 @@ describe('createOpenAPIClient', () => {
     it('raises an error if not mocked', async () => {
         const client = createOpenAPIClient('petstore', spec);
 
-        await expect(client.pet.search()).rejects.toThrow(
+        await expect(client.pet.search(req)).rejects.toThrow(
             'OpenAPI operation petstore.pet.search is not mocked',
         );
+    });
+
+    it('raises an error if invalid argument is passed', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', {
+                items: [
+                    REX,
+                ],
+            }),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.search(req, { foo: 'bar' })).rejects.toThrow(
+            'Unsupported argument: "foo" passed to: "pet.search"',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(0);
     });
 });

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { isFunction, set } from 'lodash';
 
 import { OpenAPIError } from '@globality/nodule-openapi';
 
@@ -8,8 +8,8 @@ import { OpenAPIError } from '@globality/nodule-openapi';
 export function mockResponse(name, operationId, data) {
     const obj = {};
 
-    set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async () => ({
-        data,
+    set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async (req, args) => ({
+        data: isFunction(data) ? data(args) : data,
     })));
 
     return obj;


### PR DESCRIPTION
 -  Unit tests pass `req` as usual
 -  Add unit test for request argument validation
 -  Allow data to be a callback