### PR TITLE
 Add basic auth transformation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "apollo-server-express": "^1.3.3",
+        "basic-auth": "^1.1.0",
         "connect-requestid": "^1.1.0",
         "cors": "^2.8.4",
         "express": "^4.16.3",
@@ -29,7 +30,7 @@
         "graphql": ">= 0.13.2 < 1"
     },
     "devDependencies": {
-        "@globality/nodule-config": "^2.3.0",
+        "@globality/nodule-config": "^2.4.1",
         "@globality/nodule-openapi": "^0.6.0",
         "babel-cli": "^6.26.0",
         "babel-eslint": "^8.2.2",

--- a/src/middleware/jwt/__tests__/passBasicAuth.test.js
+++ b/src/middleware/jwt/__tests__/passBasicAuth.test.js
@@ -1,0 +1,62 @@
+import { clearBinding, Nodule } from '@globality/nodule-config';
+
+import passBasicAuth from '../passBasicAuth';
+
+
+describe('passBasicAuth middleware', () => {
+    let res;
+
+    beforeEach(() => {
+        clearBinding('config');
+
+        res = {};
+        res.status = jest.fn((code) => {
+            res.code = code;
+            return res;
+        });
+        res.json = jest.fn(() => res);
+        res.setHeader = jest.fn(() => res);
+        res.set = jest.fn(() => res);
+        res.end = jest.fn(() => null);
+    });
+
+    it('sends unauthorized for missing auth', async () => {
+        const realm = 'realm';
+
+        await Nodule.testing().fromObject({
+            middleware: {
+                jwt: {
+                    realm,
+                },
+            },
+        }).load();
+
+        const req = {
+            headers: {
+            },
+        };
+
+        passBasicAuth(req, res);
+
+        expect(res.setHeader).toHaveBeenCalledTimes(1);
+        expect(res.setHeader).toHaveBeenCalledWith('WWW-Authenticate', `Basic realm="${realm}"`);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+        expect(res.end).toHaveBeenCalledTimes(1);
+        expect(res.end).toHaveBeenCalledWith();
+    });
+
+    it('turns basic auth into bearer auth', async (done) => {
+        const req = {
+            headers: {
+                authorization: `Basic ${Buffer.from('Bearer:asdf').toString('base64')}`,
+            },
+        };
+
+        passBasicAuth(req, res, () => {
+            expect(req.headers.authorization).toEqual('Bearer asdf');
+            done();
+        });
+    });
+});

--- a/src/middleware/jwt/index.js
+++ b/src/middleware/jwt/index.js
@@ -1,5 +1,6 @@
 import { bind, setDefaults } from '@globality/nodule-config';
 
+import passBasicAuth from './passBasicAuth';
 import middleware from './middleware';
 
 
@@ -27,4 +28,6 @@ setDefaults('middleware.jwt', {
     realm: null,
 });
 
+
+bind('middleware.passBasicAuth', () => passBasicAuth);
 bind('middleware.jwt', () => middleware);

--- a/src/middleware/jwt/passBasicAuth.js
+++ b/src/middleware/jwt/passBasicAuth.js
@@ -1,0 +1,24 @@
+/* Middleware that allows passing JWT via Basic Auth header.
+ *
+ * Enabling basic auth pass through greatly simplifies graphiql usage.
+ */
+import basicAuth from 'basic-auth';
+import { getConfig } from '@globality/nodule-config';
+
+import sendUnauthorized from './errors';
+
+
+export default function passBasicAuth(req, res, next) {
+    const credentials = basicAuth(req);
+    const realm = getConfig('middleware.jwt.realm');
+
+    if (!credentials) {
+        res.setHeader('WWW-Authenticate', `Basic realm="${realm}"`);
+        // XXX good log
+        return sendUnauthorized(req, res, realm);
+    }
+
+    req.headers.authorization = `${credentials.name.trim()} ${credentials.pass.trim()}`; // eslint-disable-line
+
+    return next();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@globality/nodule-config@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-config/-/nodule-config-2.3.0.tgz#402e872bfe4b801149713079be8195e5bd454386"
+"@globality/nodule-config@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-config/-/nodule-config-2.4.1.tgz#443d727ae4d9426826a5f2e59399ef2924572058"
   dependencies:
     bottlejs "^1.7.0"
     credstash "https://github.com/KensoDev/node-credstash.git#hotfix/credstash"
@@ -950,6 +950,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -1123,8 +1127,8 @@ camelize@1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000821"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz#0f3223f1e048ed96451c56ca6cf197058c42cb93"
+  version "1.0.30000823"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000823.tgz#b79842a5b5a48eaa416b73f5a5d7a23f52d26014"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1334,9 +1338,9 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
-"credstash@https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
+"credstash@git+https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
   version "1.0.1"
-  resolved "https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
+  resolved "git+https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
   dependencies:
     aes-js "0.2.2"
     async "1.5.2"
@@ -1550,8 +1554,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.30:
-  version "1.3.41"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
+  version "1.3.42"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -3929,15 +3933,15 @@ read-pkg@^2.0.0:
     path-type "^2.0.0"
 
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -4206,11 +4210,11 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@1.1.5, sax@>=0.6.0:
+sax@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
 
-sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -4477,9 +4481,9 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -4769,11 +4773,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@3.0.0, uuid@^3.0.0:
+uuid@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
Why? Some of our middlewares have basic auth built in, but our apps use jwt
auth. We can get arround this by adding a middleware to transform auth from the
basic auth format to the jwt format.

- Transform basic auth into bearer auth
- add test coverage
- pull realm from jwt config