### PR TITLE
[FIX] fixing graphiql endpoint url

### DIFF
--- a/src/routes/graphiql.js
+++ b/src/routes/graphiql.js
@@ -7,7 +7,7 @@ function makeGraphiqlOptions(config) {
     return req => ({
         /* Connect GraphiQL to GraphQL.
          */
-        endpointURL: config.routes.graphiql.endpointURL,
+        endpointURL: config.routes.graphiql.endpointUrl,
         /* Pass authorization from GraphiQL to GraphQL.
          *
          * This convention enables authenticated requests to GraphiQL to identify
@@ -19,7 +19,7 @@ function makeGraphiqlOptions(config) {
 
 
 setDefaults('routes.graphiql', {
-    endpointURL: '/graphql',
+    endpointUrl: '/content/graphql',
     enabled: false,
 });
 


### PR DESCRIPTION
Why?
The endpoint url config key is derived from environment config loader, which
turns `FOO_URL` into `fooUrl` and not `fooURL`, this PR fixes the key and sets a
better default