### PR TITLE
Add logging to OpenAPI client requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "apollo-server-express": "^1.3.3",
+        "axios": "^0.18.0",
         "connect-requestid": "^1.1.0",
         "cors": "^2.8.4",
         "express": "^4.16.3",

--- a/src/clients/logging.js
+++ b/src/clients/logging.js
@@ -1,0 +1,130 @@
+/* Client request logging.
+ */
+import { GraphQLError } from 'graphql';
+import { assign, get } from 'lodash';
+import {
+    getLogger,
+    extractLoggingProperties,
+} from '@globality/nodule-logging';
+import { getContainer } from '@globality/nodule-config';
+
+export function calculateExecuteTime(executeStartTime) {
+    const executeTime = process.hrtime(executeStartTime);
+    return (executeTime[0] * 1e3) + (executeTime[1] * 1e-6);
+}
+
+export function getElapsedTime(req) {
+    // XXX - test safe
+    if (!req._startAt) { // eslint-disable-line no-underscore-dangle
+        return 0;
+    }
+    const diff = process.hrtime(req._startAt); // eslint-disable-line no-underscore-dangle
+    return (diff[0] * 1e3) + (diff[1] * 1e-6);
+}
+
+export function buildRequestLogs(req, serviceName, operationName, request) {
+    const { config } = getContainer();
+    const { data, params } = request;
+    const args = assign({}, params, data);
+    return {
+        serviceName,
+        serviceRequestName: operationName,
+        ...(params ? { serviceRequestArgs: Object.keys(args) } : {}),
+        ...extractLoggingProperties(
+            { params: args },
+            get(config, 'logging.backendServiceRequestRules', []),
+        ),
+    };
+}
+
+
+export function logSuccess(req, request, response, requestLogs, executeStartTime) {
+    const { method, url } = request;
+    const { config } = getContainer();
+    const logger = getLogger();
+    const executeTime = calculateExecuteTime(executeStartTime);
+    const logs = {
+        serviceResponseTimeMs: executeTime,
+        ...requestLogs,
+        ...extractLoggingProperties(
+            { url: url.split('?')[0], method },
+            get(config, 'logging.backendServiceRequestRules', []),
+        ),
+        ...extractLoggingProperties(
+            response,
+            get(config, 'logging.backendServiceResponseRules', []),
+        ),
+    };
+    if (get(config, 'logging.slownessWarning.enabled', false) &&
+        executeTime > get(config, 'logging.slownessWarning.warnForServiceResponseTimeMs', 1000)) {
+        logger.warning(req, 'ServiceSlownessWarning', logs);
+    }
+    if (get(config, 'logging.serviceRequestSucceeded.enabled', false)) {
+        logger.info(req, 'ServiceRequestSucceeded', logs);
+    }
+    // XXX - move this code
+    if (getElapsedTime(req) > get(config, 'perfomance.maxExecutionTimeMs')) {
+        logger.warning(req, 'MaxExecutionTimePassed', logs);
+        throw new GraphQLError('MaxExecutionTimePassed');
+    }
+}
+
+
+export function extractErrorData(error) {
+    const response = get(error, 'response');
+
+    if (response) {
+        return get(response, 'data');
+    }
+
+    return get(error, 'data');
+}
+
+
+export function extractErrorMessage(error) {
+    const responseData = get(error, 'response.data');
+
+    if (responseData) {
+        return get(responseData, 'message');
+    }
+
+    return get(error, 'message');
+}
+
+export function extractErrorStatus(error) {
+    const response = get(error, 'response');
+
+    if (response) {
+        return get(response, 'status') || get(response, 'code');
+    }
+
+    return get(error, 'status') || get(error, 'code');
+}
+
+
+export function logFailure(req, request, error, requestLogs) {
+    const { method, url } = request;
+    const logger = getLogger();
+    const { config } = getContainer();
+    const errorData = extractErrorData(error);
+    const errorMessage = extractErrorMessage(error);
+    const errorStatus = extractErrorStatus(error);
+
+    const logs = {
+        errorMessage,
+        status: errorStatus,
+        errorData,
+        ...requestLogs,
+        ...extractLoggingProperties(
+            { url, method },
+            get(config, 'logging.backendServiceRequestRules', []),
+        ),
+    };
+
+    if (errorStatus && errorStatus < 500) {
+        // HTTP statuses in the 4XX range expected and not warnings
+        logger.info(req, 'ServiceRequestFailed', logs);
+    } else {
+        logger.warn(req, 'ServiceRequestFailed', logs);
+    }
+}

--- a/src/clients/logging.js
+++ b/src/clients/logging.js
@@ -1,6 +1,5 @@
 /* Client request logging.
  */
-import { GraphQLError } from 'graphql';
 import { assign, get } from 'lodash';
 import {
     getLogger,
@@ -14,7 +13,6 @@ export function calculateExecuteTime(executeStartTime) {
 }
 
 export function getElapsedTime(req) {
-    // XXX - test safe
     if (!req._startAt) { // eslint-disable-line no-underscore-dangle
         return 0;
     }
@@ -29,10 +27,10 @@ export function buildRequestLogs(req, serviceName, operationName, request) {
     return {
         serviceName,
         serviceRequestName: operationName,
-        ...(params ? { serviceRequestArgs: Object.keys(args) } : {}),
+        ...(args ? { serviceRequestArgs: Object.keys(args) } : {}),
         ...extractLoggingProperties(
             { params: args },
-            get(config, 'logging.backendServiceRequestRules', []),
+            get(config, 'logging.serviceRequestRules', []),
         ),
     };
 }
@@ -48,11 +46,11 @@ export function logSuccess(req, request, response, requestLogs, executeStartTime
         ...requestLogs,
         ...extractLoggingProperties(
             { url: url.split('?')[0], method },
-            get(config, 'logging.backendServiceRequestRules', []),
+            get(config, 'logging.serviceRequestRules', []),
         ),
         ...extractLoggingProperties(
             response,
-            get(config, 'logging.backendServiceResponseRules', []),
+            get(config, 'logging.serviceResponseRules', []),
         ),
     };
     if (get(config, 'logging.slownessWarning.enabled', false) &&
@@ -61,11 +59,6 @@ export function logSuccess(req, request, response, requestLogs, executeStartTime
     }
     if (get(config, 'logging.serviceRequestSucceeded.enabled', false)) {
         logger.info(req, 'ServiceRequestSucceeded', logs);
-    }
-    // XXX - move this code
-    if (getElapsedTime(req) > get(config, 'perfomance.maxExecutionTimeMs')) {
-        logger.warning(req, 'MaxExecutionTimePassed', logs);
-        throw new GraphQLError('MaxExecutionTimePassed');
     }
 }
 
@@ -117,7 +110,7 @@ export function logFailure(req, request, error, requestLogs) {
         ...requestLogs,
         ...extractLoggingProperties(
             { url, method },
-            get(config, 'logging.backendServiceRequestRules', []),
+            get(config, 'logging.serviceRequestRules', []),
         ),
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,9 +1397,9 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
-"credstash@git+https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
+"credstash@https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
   version "1.0.1"
-  resolved "git+https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
+  resolved "https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
   dependencies:
     aes-js "0.2.2"
     async "1.5.2"
@@ -2801,7 +2801,7 @@ is-utf8@^0.2.0:
 
 is-uuid@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-uuid/-/is-uuid-1.0.2.tgz#ad1898ddf154947c25c8e54966f48604e9caecc4"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/is-uuid/-/is-uuid-1.0.2.tgz#ad1898ddf154947c25c8e54966f48604e9caecc4"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -5221,3 +5221,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.5.1:
+  version "1.6.0"
+  resolved "https://globality.jfrog.io/globality/api/npm/npm/yarn/-/yarn-1.6.0.tgz#9cec6f7986dc237d39ec705ce74d95155fe55d4b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,7 +2801,7 @@ is-utf8@^0.2.0:
 
 is-uuid@^1.0.2:
   version "1.0.2"
-  resolved "https://globality.jfrog.io/globality/api/npm/npm/is-uuid/-/is-uuid-1.0.2.tgz#ad1898ddf154947c25c8e54966f48604e9caecc4"
+  resolved "https://registry.yarnpkg.com/is-uuid/-/is-uuid-1.0.2.tgz#ad1898ddf154947c25c8e54966f48604e9caecc4"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -5224,4 +5224,4 @@ yargs@~3.10.0:
 
 yarn@^1.5.1:
   version "1.6.0"
-  resolved "https://globality.jfrog.io/globality/api/npm/npm/yarn/-/yarn-1.6.0.tgz#9cec6f7986dc237d39ec705ce74d95155fe55d4b"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.6.0.tgz#9cec6f7986dc237d39ec705ce74d95155fe55d4b"


### PR DESCRIPTION
We turn off logging for OpenAPI client requests during testing as it produces a lot of noise.

Set the logging properties using setDefaults('logging', <logging parameters>) on the given service.