### PR TITLE
Hotfix/0.11.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/middleware/jwt/middleware.js
+++ b/src/middleware/jwt/middleware.js
@@ -48,7 +48,7 @@ export default function middleware(req, res, next) {
     return validator(req, res, (error) => {
         if (error) {
             const logger = getLogger();
-            logger.info('Unauthorized:  jwt validation', error);
+            logger.info(req, 'Unauthorized:  jwt validation', error);
             return sendUnauthorized(req, res, realm);
         }
         return next();

--- a/src/middleware/jwt/passBasicAuth.js
+++ b/src/middleware/jwt/passBasicAuth.js
@@ -16,20 +16,20 @@ export default function passBasicAuth(req, res, next) {
     const { authorization } = req.headers;
 
     if (!authorization) {
-        logger.info('Unauthorized: missing auth');
+        logger.info(req, 'Unauthorized: missing auth');
         return sendUnauthorized(req, res, realm);
     }
     const [prefix, payload] = authorization.split(' ');
 
     if (!payload || prefix.toLowerCase() !== 'basic') {
-        logger.info('Unauthorized: wrong scheme');
+        logger.info(req, 'Unauthorized: wrong scheme');
         return sendUnauthorized(req, res, realm);
     }
 
     const credentials = Buffer.from(payload, 'base64').toString('utf-8').split(':');
 
     if (!credentials || credentials.length !== 2) {
-        logger.info('Unauthorized: wrong format');
+        logger.info(req, 'Unauthorized: wrong format');
         return sendUnauthorized(req, res, realm);
     }
 


### PR DESCRIPTION
We were passing the log message where the req should go and so the log format was wrong.

We were getting:

```
{
  "level": "info",
  "message": "undefined"
}
```

Now we get:

```
{
  "level": "info",
  "message": "Unauthorized: missing auth"
}

```