### PR TITLE
Fix errors associated with openapi error logging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "devDependencies": {
         "@globality/nodule-config": "~2.4.1",
-        "@globality/nodule-logging": "~1.2.0",
+        "@globality/nodule-logging": "~1.2.2",
         "@globality/nodule-openapi": "~0.6.0",
         "babel-cli": "^6.26.0",
         "babel-eslint": "^8.2.2",

--- a/src/clients/__tests__/logging.test.js
+++ b/src/clients/__tests__/logging.test.js
@@ -1,0 +1,29 @@
+import { clearBinding, Nodule } from '@globality/nodule-config';
+
+import spec from 'testing/petstore.json';
+import { logFailure, logSuccess } from '../logging';
+
+
+describe('OpenAPIClient logging', () => {
+    it('logs failures', async () => {
+        const error = {
+            data: 'err data',
+            status: 500,
+        };
+        logFailure({}, { method: 'GET', url: '/test'}, error, {});
+    });
+
+    it('logs successes', async () => {
+        const error = {
+            data: 'err data',
+            status: 500,
+        };
+        logSuccess(
+            {},
+            { method: 'GET', url: '/test'},
+            {},
+            {},
+            process.hrtime(),
+        );
+    });
+});

--- a/src/clients/logging.js
+++ b/src/clients/logging.js
@@ -118,6 +118,6 @@ export function logFailure(req, request, error, requestLogs) {
         // HTTP statuses in the 4XX range expected and not warnings
         logger.info(req, 'ServiceRequestFailed', logs);
     } else {
-        logger.warn(req, 'ServiceRequestFailed', logs);
+        logger.warning(req, 'ServiceRequestFailed', logs);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,9 +86,9 @@
     credstash "https://github.com/KensoDev/node-credstash.git#hotfix/credstash"
     lodash "^4.17.5"
 
-"@globality/nodule-logging@~1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-logging/-/nodule-logging-1.2.0.tgz#dd10f5460a86192e710333f979d7ebcc8639c025"
+"@globality/nodule-logging@~1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-logging/-/nodule-logging-1.2.2.tgz#ec13a78349f0f37a3d09ae2b5ac90a104001569b"
   dependencies:
     is-uuid "^1.0.2"
     lodash "^4.17.4"


### PR DESCRIPTION
- Bump version of nodule-logging to include a hotfix we need from that
lib
- Fix an incorrect logger call in the openapi logging
- Add test coverage to exercise relevant code paths.