### PR TITLE
Instantiate logger through bottle

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.3
+current_version = 0.12.4
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.12.3",
+    "version": "0.12.4",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/clients/logging.js
+++ b/src/clients/logging.js
@@ -2,7 +2,6 @@
  */
 import { assign, get } from 'lodash';
 import {
-    getLogger,
     extractLoggingProperties,
 } from '@globality/nodule-logging';
 import { getContainer } from '@globality/nodule-config';
@@ -38,8 +37,7 @@ export function buildRequestLogs(req, serviceName, operationName, request) {
 
 export function logSuccess(req, request, response, requestLogs, executeStartTime) {
     const { method, url } = request;
-    const { config } = getContainer();
-    const logger = getLogger();
+    const { config, logger } = getContainer();
     const executeTime = calculateExecuteTime(executeStartTime);
     const logs = {
         serviceResponseTimeMs: executeTime,
@@ -97,8 +95,7 @@ export function extractErrorStatus(error) {
 
 export function logFailure(req, request, error, requestLogs) {
     const { method, url } = request;
-    const logger = getLogger();
-    const { config } = getContainer();
+    const { config, logger } = getContainer();
     const errorData = extractErrorData(error);
     const errorMessage = extractErrorMessage(error);
     const errorStatus = extractErrorStatus(error);

--- a/src/middleware/jwt/__tests__/passBasicAuth.test.js
+++ b/src/middleware/jwt/__tests__/passBasicAuth.test.js
@@ -1,4 +1,5 @@
 import { clearBinding, Nodule } from '@globality/nodule-config';
+import '@globality/nodule-logging'; // factory import
 
 import passBasicAuth from '../passBasicAuth';
 

--- a/src/middleware/jwt/middleware.js
+++ b/src/middleware/jwt/middleware.js
@@ -1,7 +1,6 @@
 import jwt from 'express-jwt';
 
-import { getConfig, getMetadata } from '@globality/nodule-config';
-import { getLogger } from '@globality/nodule-logging';
+import { getConfig, getMetadata, getContainer } from '@globality/nodule-config';
 
 import sendUnauthorized from './errors';
 import negotiateKey from './negotiate';
@@ -47,7 +46,7 @@ export default function middleware(req, res, next) {
 
     return validator(req, res, (error) => {
         if (error) {
-            const logger = getLogger();
+            const { logger } = getContainer();
             logger.info(req, `jwt validation failed: ${error.message}`, error);
             return sendUnauthorized(req, res, realm);
         }

--- a/src/middleware/jwt/passBasicAuth.js
+++ b/src/middleware/jwt/passBasicAuth.js
@@ -2,14 +2,13 @@
  *
  * Enabling basic auth pass through greatly simplifies graphiql usage.
  */
-import { getConfig } from '@globality/nodule-config';
-import { getLogger } from '@globality/nodule-logging';
+import { getConfig, getContainer } from '@globality/nodule-config';
 
 import sendUnauthorized from './errors';
 
 
 export default function passBasicAuth(req, res, next) {
-    const logger = getLogger();
+    const { logger } = getContainer();
 
     const realm = getConfig('middleware.jwt.realm');
 

--- a/src/middleware/jwt/passBasicAuth.js
+++ b/src/middleware/jwt/passBasicAuth.js
@@ -3,7 +3,6 @@
  * Enabling basic auth pass through greatly simplifies graphiql usage.
  */
 import { getConfig, getContainer } from '@globality/nodule-config';
-import '@globality/nodule-logging';
 
 import sendUnauthorized from './errors';
 

--- a/src/middleware/jwt/passBasicAuth.js
+++ b/src/middleware/jwt/passBasicAuth.js
@@ -3,6 +3,7 @@
  * Enabling basic auth pass through greatly simplifies graphiql usage.
  */
 import { getConfig, getContainer } from '@globality/nodule-config';
+import '@globality/nodule-logging';
 
 import sendUnauthorized from './errors';
 


### PR DESCRIPTION
Why? Calling getLogger directly creates a new winston instance under the hood. Winston will create a memory leak by registering too many listeners to the same event if it is instantiated too many times.