### PR TITLE
Enable resolver resolution to use function to generate a name.

### DIFF
--- a/src/__tests__/resolvers.test.js
+++ b/src/__tests__/resolvers.test.js
@@ -1,0 +1,26 @@
+import { Nodule } from '@globality/nodule-config';
+
+import { getResolver } from 'index';
+
+
+describe('resolvers', () => {
+    beforeEach(async () => {
+        await Nodule.testing().load();
+    });
+
+    it('returns the null resolver', async () => {
+        const resolver = getResolver('null');
+        expect(resolver).toBeDefined();
+
+        const result = await resolver();
+        expect(result).toBeNull();
+    });
+
+    it('returns the null resolver from a function', async () => {
+        const resolver = getResolver(() => 'null');
+        expect(resolver).toBeDefined();
+
+        const result = await resolver();
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
This small hook means that some of our cases where we use a different
resolver based on user input can be handled by writing a helper function
to choose a resolver by name.

In addition, I added a "null" resolver which a) helps with testing and
b) helps with cases where one of the branch paths for the above hook
wants to return null instead of resolving something.