### PR TITLE
Support resolving authorizers by name

### DIFF
--- a/src/authorizers/index.js
+++ b/src/authorizers/index.js
@@ -1,0 +1,6 @@
+import { bind } from '@globality/nodule-config';
+
+
+/* Register a default 'null' authorizer.
+ */
+bind('graphql.authorizers.null', () => () => true);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // activate component bindings
+import './authorizers';
 import './middleware';
 import './routes';
 import './terminal';
@@ -15,7 +16,7 @@ export {
     createResolver,
     createStrictResolver,
     getResolver,
-} from './resolver';
+} from './resolvers';
 export {
     all,
     any,

--- a/src/resolvers/__tests__/test.null.js
+++ b/src/resolvers/__tests__/test.null.js
@@ -1,0 +1,26 @@
+import { Nodule } from '@globality/nodule-config';
+
+import { getResolver } from 'index';
+
+
+describe('null resolver', () => {
+    beforeEach(async () => {
+        await Nodule.testing().load();
+    });
+
+    it('is available by name', async () => {
+        const resolver = getResolver('null');
+        expect(resolver).toBeDefined();
+
+        const result = await resolver();
+        expect(result).toBeNull();
+    });
+
+    it('is available by function call', async () => {
+        const resolver = getResolver(() => 'null');
+        expect(resolver).toBeDefined();
+
+        const result = await resolver();
+        expect(result).toBeNull();
+    });
+});

--- a/src/resolvers/__tests__/test.resolver.js
+++ b/src/resolvers/__tests__/test.resolver.js
@@ -1,9 +1,5 @@
-import { Nodule } from '@globality/nodule-config';
-
 import {
     createResolver,
-    createStrictResolver,
-    getResolver,
     Forbidden,
 } from 'index';
 
@@ -73,63 +69,13 @@ describe('a resolver', () => {
         });
         await expect(resolver.resolve()).rejects.toThrow('Forbidden');
     });
-});
 
-
-describe('null resolver', () => {
-    beforeEach(async () => {
-        await Nodule.testing().load();
-    });
-
-    it('is available by name', async () => {
-        const resolver = getResolver('null');
-        expect(resolver).toBeDefined();
-
-        const result = await resolver();
-        expect(result).toBeNull();
-    });
-
-    it('is available by function call', async () => {
-        const resolver = getResolver(() => 'null');
-        expect(resolver).toBeDefined();
-
-        const result = await resolver();
-        expect(result).toBeNull();
-    });
-});
-
-
-describe('a strict resolver', () => {
-    it('requires an aggregate function', async () => {
-        expect(
-            () => createStrictResolver({
-                authorize: () => true,
-                transform: value => value,
-            }),
-        ).toThrow(
-            'Strict resolver must define an `aggregate` option',
-        );
-    });
-
-    it('requires an authorize function', async () => {
-        expect(
-            () => createStrictResolver({
-                aggregate: async () => null,
-                transform: value => value,
-            }),
-        ).toThrow(
-            'Strict resolver must define an `authorize` option',
-        );
-    });
-
-    it('requires a transform function', async () => {
-        expect(
-            () => createStrictResolver({
-                aggregate: async () => null,
-                authorize: () => true,
-            }),
-        ).toThrow(
-            'Strict resolver must define a `transform` option',
-        );
+    it('authorizes based on an authorizer name', async () => {
+        const resolver = createResolver({
+            aggregate: async () => 21,
+            authorize: 'null',
+            transform: result => 2 * result,
+        });
+        expect(await resolver.resolve()).toEqual(42);
     });
 });

--- a/src/resolvers/__tests__/test.strict.js
+++ b/src/resolvers/__tests__/test.strict.js
@@ -1,0 +1,39 @@
+import {
+    createStrictResolver,
+} from 'index';
+
+
+describe('a strict resolver', () => {
+    it('requires an aggregate function', async () => {
+        expect(
+            () => createStrictResolver({
+                authorize: () => true,
+                transform: value => value,
+            }),
+        ).toThrow(
+            'Strict resolver must define an `aggregate` option',
+        );
+    });
+
+    it('requires an authorize function', async () => {
+        expect(
+            () => createStrictResolver({
+                aggregate: async () => null,
+                transform: value => value,
+            }),
+        ).toThrow(
+            'Strict resolver must define an `authorize` option',
+        );
+    });
+
+    it('requires a transform function', async () => {
+        expect(
+            () => createStrictResolver({
+                aggregate: async () => null,
+                authorize: () => true,
+            }),
+        ).toThrow(
+            'Strict resolver must define a `transform` option',
+        );
+    });
+});

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -44,10 +44,15 @@ export class Resolver {
         const masked = this.mask(obj, args, context, info);
 
         if (this.authorize) {
+            // allow authorizer to be looked up by name
+            const authorize = isFunction(this.authorize)
+                ? this.authorize
+                : getContainer(`graphql.authorizers.${this.authorize}`);
+
             if (isNil(this.authorizeData)) {
-                await this.authorize(...masked);
+                await authorize(...masked);
             } else {
-                await this.authorize(this.authorizeData, ...masked);
+                await authorize(this.authorizeData, ...masked);
             }
         }
 


### PR DESCRIPTION
Changes:
 -  Move resolvers to a directory structure and break tests into parts
 -  Add a null authorizer binding
 -  Allow authorizers to be passed by name