### PR TITLE
Pass unmasked parameters to authorize

### DIFF
--- a/src/__tests__/resolvers.js
+++ b/src/__tests__/resolvers.js
@@ -17,8 +17,8 @@ const retrieveUser = createResolver({
         const { services } = getContainer();
         return services.user.retrieve(userId);
     },
-    authorize: ({ userId }) => {
-        if (userId === '23') {
+    authorize: (obj, { id }) => {
+        if (id === '23') {
             throw new Forbidden('Not Authorized');
         }
         return true;

--- a/src/resolvers/types.js
+++ b/src/resolvers/types.js
@@ -41,20 +41,22 @@ export class Resolver {
 
     // NB: async class methods were added to node in v8.x
     async resolve(obj, args, context, info) {
-        const masked = this.mask(obj, args, context, info);
-
         if (this.authorize) {
             // allow authorizer to be looked up by name
             const authorize = isFunction(this.authorize)
                 ? this.authorize
                 : getContainer(`graphql.authorizers.${this.authorize}`);
 
+            // always invoke authorizers with standard resolver arguments
             if (isNil(this.authorizeData)) {
-                await authorize(...masked);
+                await authorize(obj, args, context, info);
             } else {
-                await authorize(this.authorizeData, ...masked);
+                await authorize(this.authorizeData, obj, args, context, info);
             }
         }
+
+        // apply mask function
+        const masked = this.mask(obj, args, context, info);
 
         // aggregate asynchronous requests over services.
         const aggregated = await this.aggregate(...masked);


### PR DESCRIPTION
After some experience with larger configurations, the value of `mask` is to simplify
invocations to `aggregate` (and to a lesser extent `transform`). It turns out to be
useful to have different masks for different resolvers... but to have unified
authorization implementations. So: pass the pre-masked arguments.

Not backwards compatible, but our current surface area for authorization is small.