### PR TITLE
Add services functionality to nodule-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Resolvers should throw errors when something fails. Within `nodule-graphql`, it 
  -  Most errors will borrow from HTTP error codes (because they have well-known, useful semantics)
  -  Error codes should be visible to API consumers via `error.extensions`
 
+## Services
+
+`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all
+defined endpoints.
+
+For usage see the README in the services folder.
 
 ## Local Development
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "axios": "^0.18.0",
         "connect-requestid": "^1.1.0",
         "cors": "^2.8.4",
+        "dataloader": "^1.4.0",
         "express": "^4.16.3",
         "express-jwt": "^5.3.1",
         "helmet": "^3.12.0",
@@ -24,6 +25,7 @@
         "jsonwebtoken": "^8.2.0",
         "lodash": "^4.17.5",
         "throat": "^4.1.0",
+        "uuid": "^3.2.1",
         "yarn": "^1.5.1"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "babel src --out-dir lib --ignore '**/__tests__/*,**/__mocks__/*'",
         "lint": "eslint src --cache",
-        "test": "jest src",
+        "test": "jest",
         "verify": "yarn lint && yarn test"
     },
     "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -34,4 +34,4 @@ export {
     signPrivate,
 } from './testing';
 export { wrapResolvers } from './wrapper';
-export { bindServices } from './services';
+export { default as bindServices } from './services';

--- a/src/index.js
+++ b/src/index.js
@@ -34,3 +34,4 @@ export {
     signPrivate,
 } from './testing';
 export { wrapResolvers } from './wrapper';
+export { bindServices } from './services';

--- a/src/modules/concurrency.js
+++ b/src/modules/concurrency.js
@@ -12,7 +12,6 @@ function getConcurrency(concurrencyLimit) {
     if (!isNil(concurrencyLimit)) {
         return concurrencyLimit;
     }
-
     return parseInt(getConfig('concurrency.limit') || DEFAULT_CONCURRENCY, 10);
 }
 

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -101,4 +101,9 @@ These wrappers can be included by binding to the `serviceWrappers` container:
 the ability to override this function. The function should be able to generate a unique key given
 a list of arguments.
 
-    bind('createKey', createKey);
+    function createKey(args) {
+        ... calculate key based on args ...
+        return key;
+    }
+
+    bind('createKey', () => createKey);

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,98 @@
+# Services
+
+`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all defined endpoints.
+
+## Usage
+
+1. OpenAPI Clients Container Name
+    All of OpenAPI clients that are to be converted into wrapped services need to be bound to a container.
+    The default name of `clients` can be used for the container or can be overridden by binding to `clientsName`:
+
+        Object.keys(specs).forEach((name) => {
+            bind(`fooClients.${name}`, () => createOpenAPIClient(name, specs[name]));
+        });
+        bind('clientsName', 'fooClients');
+
+2. Specifying Configs
+
+    There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
+    In order to utilize these wrappers, configuration variables need to be bound.
+
+    In order to generate a unique hashable key for a specific service request, a unique ID is used. To use any
+    of the services, bind a specific UUID to `uniqueId`.
+
+        bind('uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
+
+    The paths specified in the configurations should be retrievable from:
+        getContainer(`{clientsName}.{path}`)
+
+    dedup:
+        const dedupConfig = {
+            'path.to.foo.endpoint': {},
+            'path.to.bar.endpoint': {},
+        }
+        bind('dedupConfig', dedupConfig);
+
+    batch:
+        For a given path the `accumulateBy` and `accumulateInto` should include a field that can be grouped
+        into a different parameter to be passed into the same endpoint. In addition the returned response
+        must include the `accumulateBy` field as one of the properties. If it doesnt, specify a `splitResponseBy`
+        field to split the returned response by. If the batched endpoint is different than the original
+        request, this can be specified with `batchSearchRequest` field. Finally if specific parameters need
+        to be included during batched requests, the `assignArgs` parameter can be used.
+
+        const batchConfig = {
+            'path.to.foo.endpoint': {
+                accumulateBy: 'foo',
+                accumulateInto: 'foos',
+            },
+            'path.to.bar.endpoint': {
+                accumulateBy: 'bar',
+                accumulateInto: 'bars',
+                splitResponseBy: 'baz',
+                assignArgs: [
+                    {
+                        additionParameter: 'parameter',
+                    },
+                ],
+                batchSearchRequest: named('path.to.bars.endpoint'),
+            },
+        }
+        bind('batchConfig', batchConfig);
+
+3. Additional wrappers
+
+    `nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way to expect (req, args)
+    parameters, and only operate on endpoints specified in an associated config.
+
+    These wrappers can be included by binding to the `serviceWrappers` container:
+        const serviceWrappers = [
+            [fooWrapperConfig, fooWrapper],
+            [barWrapperConfig, barWrapper],
+        ];
+        bind('serviceWrappers', serviceWrappers);
+
+4. Import `bindServices`
+
+    In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the clients and config
+    bindings have been bound.
+
+        import { bindServices } from '@globality/nodule-graphql';
+
+        import fooClients;
+        import barServiceConfig;
+
+        bindServices();
+
+5. Using services
+
+    The wrapped services will be bound to the `services` field. In order to use the wrapped clients, simply replace the client
+    getContainer call with a `services` get container call:
+
+        const { foo, bar } = getContainer('services');
+
+    The original `clients` are still bound so if for a specific endpoint, the services are not desired, the client version
+    of the call is still accessiable:
+
+        const { foo, bar } = getContainer('services');
+        const { baz } = getContainer('services');

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,10 +1,13 @@
 # Services
 
-`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all defined endpoints.
+`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all
+defined endpoints.
 
 ## Usage
 
-1. OpenAPI Clients Container Name
+All usage details can be found below.
+
+### OpenAPI Clients Container Name
     All of OpenAPI clients that are to be converted into wrapped services need to be bound to a container.
     The default name of `clients` can be used for the container or can be overridden by binding to `clientsName`:
 
@@ -13,7 +16,7 @@
         });
         bind('clientsName', 'fooClients');
 
-2. Specifying Configs
+### Specifying Configs
 
     There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
     In order to utilize these wrappers, configuration variables need to be bound.
@@ -26,14 +29,14 @@
     The paths specified in the configurations should be retrievable from:
         getContainer(`{clientsName}.{path}`)
 
-    dedup:
+    `dedup`:
         const dedupConfig = {
             'path.to.foo.endpoint': {},
             'path.to.bar.endpoint': {},
         }
         bind('dedupConfig', dedupConfig);
 
-    batch:
+    `batch`:
         For a given path the `accumulateBy` and `accumulateInto` should include a field that can be grouped
         into a different parameter to be passed into the same endpoint. In addition the returned response
         must include the `accumulateBy` field as one of the properties. If it doesnt, specify a `splitResponseBy`
@@ -60,10 +63,10 @@
         }
         bind('batchConfig', batchConfig);
 
-3. Additional wrappers
+### Additional wrappers
 
-    `nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way to expect (req, args)
-    parameters, and only operate on endpoints specified in an associated config.
+    `nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way 
+    to expect (req, args) parameters, and only operate on endpoints specified in an associated config.
 
     These wrappers can be included by binding to the `serviceWrappers` container:
         const serviceWrappers = [
@@ -72,10 +75,10 @@
         ];
         bind('serviceWrappers', serviceWrappers);
 
-4. Import `bindServices`
+### Import `bindServices`
 
-    In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the clients and config
-    bindings have been bound.
+    In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
+    clients and config bindings have been bound.
 
         import { bindServices } from '@globality/nodule-graphql';
 
@@ -84,15 +87,15 @@
 
         bindServices();
 
-5. Using services
+### Using services
 
-    The wrapped services will be bound to the `services` field. In order to use the wrapped clients, simply replace the client
-    getContainer call with a `services` get container call:
+    The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
+    simply replace the client getContainer call with a `services` get container call:
 
         const { foo, bar } = getContainer('services');
 
-    The original `clients` are still bound so if for a specific endpoint, the services are not desired, the client version
-    of the call is still accessiable:
+    The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
+    the client version of the call is still accessiable:
 
         const { foo, bar } = getContainer('services');
         const { baz } = getContainer('services');

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -94,3 +94,11 @@ These wrappers can be included by binding to the `serviceWrappers` container:
         [barWrapperConfig, barWrapper],
     ];
     bind('serviceConfig.additionalWrappers', serviceWrappers);
+
+## Override createKey
+
+`nodule-graphql` generates a unique key to be used for batching/deduplication. The library allows
+the ability to override this function. The function should be able to generate a unique key given
+a list of arguments.
+
+    bind('createKey', createKey);

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -3,99 +3,99 @@
 `nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all
 defined endpoints.
 
-## Usage
+## OpenAPI Clients Container Name
 
-All usage details can be found below.
+All of OpenAPI clients that are to be converted into wrapped services need to be bound to a container.
+The default name of `clients` can be used for the container or can be overridden by binding to `clientsName`:
 
-### OpenAPI Clients Container Name
-    All of OpenAPI clients that are to be converted into wrapped services need to be bound to a container.
-    The default name of `clients` can be used for the container or can be overridden by binding to `clientsName`:
+    Object.keys(specs).forEach((name) => {
+        bind(`fooClients.${name}`, () => createOpenAPIClient(name, specs[name]));
+    });
+    bind('clientsName', 'fooClients');
 
-        Object.keys(specs).forEach((name) => {
-            bind(`fooClients.${name}`, () => createOpenAPIClient(name, specs[name]));
-        });
-        bind('clientsName', 'fooClients');
+## Specifying Configs
 
-### Specifying Configs
+There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
+In order to utilize these wrappers, configuration variables need to be bound.
 
-    There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
-    In order to utilize these wrappers, configuration variables need to be bound.
+In order to generate a unique hashable key for a specific service request, a unique ID is used. To use any
+of the services, bind a specific UUID to `uniqueId`.
 
-    In order to generate a unique hashable key for a specific service request, a unique ID is used. To use any
-    of the services, bind a specific UUID to `uniqueId`.
+    bind('uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
 
-        bind('uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
+The paths specified in the configurations should be retrievable from:
 
-    The paths specified in the configurations should be retrievable from:
-        getContainer(`{clientsName}.{path}`)
+    getContainer(`{clientsName}.{path}`)
 
-    `dedup`:
-        const dedupConfig = {
-            'path.to.foo.endpoint': {},
-            'path.to.bar.endpoint': {},
-        }
-        bind('dedupConfig', dedupConfig);
+### dedup
 
-    `batch`:
-        For a given path the `accumulateBy` and `accumulateInto` should include a field that can be grouped
-        into a different parameter to be passed into the same endpoint. In addition the returned response
-        must include the `accumulateBy` field as one of the properties. If it doesnt, specify a `splitResponseBy`
-        field to split the returned response by. If the batched endpoint is different than the original
-        request, this can be specified with `batchSearchRequest` field. Finally if specific parameters need
-        to be included during batched requests, the `assignArgs` parameter can be used.
+    const dedupConfig = {
+        'path.to.foo.endpoint': {},
+        'path.to.bar.endpoint': {},
+    }
+    bind('dedupConfig', dedupConfig);
 
-        const batchConfig = {
-            'path.to.foo.endpoint': {
-                accumulateBy: 'foo',
-                accumulateInto: 'foos',
-            },
-            'path.to.bar.endpoint': {
-                accumulateBy: 'bar',
-                accumulateInto: 'bars',
-                splitResponseBy: 'baz',
-                assignArgs: [
-                    {
-                        additionParameter: 'parameter',
-                    },
-                ],
-                batchSearchRequest: named('path.to.bars.endpoint'),
-            },
-        }
-        bind('batchConfig', batchConfig);
+### batch
 
-### Additional wrappers
+For a given path the `accumulateBy` and `accumulateInto` should include a field that can be grouped
+into a different parameter to be passed into the same endpoint. In addition the returned response
+must include the `accumulateBy` field as one of the properties. If it doesnt, specify a `splitResponseBy`
+field to split the returned response by. If the batched endpoint is different than the original
+request, this can be specified with `batchSearchRequest` field. Finally if specific parameters need
+to be included during batched requests, the `assignArgs` parameter can be used.
 
-    `nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way 
-    to expect (req, args) parameters, and only operate on endpoints specified in an associated config.
+    const batchConfig = {
+        'path.to.foo.endpoint': {
+            accumulateBy: 'foo',
+            accumulateInto: 'foos',
+        },
+        'path.to.bar.endpoint': {
+            accumulateBy: 'bar',
+            accumulateInto: 'bars',
+            splitResponseBy: 'baz',
+            assignArgs: [
+                {
+                    additionParameter: 'parameter',
+                },
+            ],
+            batchSearchRequest: named('path.to.bars.endpoint'),
+        },
+    }
+    bind('batchConfig', batchConfig);
 
-    These wrappers can be included by binding to the `serviceWrappers` container:
-        const serviceWrappers = [
-            [fooWrapperConfig, fooWrapper],
-            [barWrapperConfig, barWrapper],
-        ];
-        bind('serviceWrappers', serviceWrappers);
+## Additional wrappers
 
-### Import `bindServices`
+`nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way 
+to expect (req, args) parameters, and only operate on endpoints specified in an associated config.
 
-    In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
-    clients and config bindings have been bound.
+These wrappers can be included by binding to the `serviceWrappers` container:
+    const serviceWrappers = [
+        [fooWrapperConfig, fooWrapper],
+        [barWrapperConfig, barWrapper],
+    ];
+    bind('serviceWrappers', serviceWrappers);
 
-        import { bindServices } from '@globality/nodule-graphql';
+## Import `bindServices`
 
-        import fooClients;
-        import barServiceConfig;
+In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
+clients and config bindings have been bound.
 
-        bindServices();
+    import { bindServices } from '@globality/nodule-graphql';
 
-### Using services
+    import fooClients;
+    import barServiceConfig;
 
-    The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
-    simply replace the client getContainer call with a `services` get container call:
+    bindServices();
 
-        const { foo, bar } = getContainer('services');
+## Using services
 
-    The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
-    the client version of the call is still accessiable:
+The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
+simply replace the client getContainer call with a `services` get container call:
 
-        const { foo, bar } = getContainer('services');
-        const { baz } = getContainer('services');
+    const { foo, bar } = getContainer('services');
+
+The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
+the client version of the call is still accessiable:
+
+    const { foo, bar } = getContainer('services');
+    const { baz } = getContainer('services');

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -13,14 +13,30 @@ The default name of `clients` can be used for the container or can be overridden
     });
     bind('clientsName', 'fooClients');
 
-## Unique Key
+## Import `bindServices`
 
-In order to generate a unique hashable key for a specific service request, a unique ID is used. To use any
-of the services, bind a specific UUID to `uniqueId`.
+In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
+clients and config bindings have been bound.
 
-    bind('serviceConfig.uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
+    import { bindServices } from '@globality/nodule-graphql';
 
-Alternatively the default uniqueId of '00000000-0000-0000-0000-000000000000' will be used.
+    import fooClients;
+    import barServiceConfig;
+
+    bindServices();
+
+## Using services
+
+The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
+simply replace the client getContainer call with a `services` get container call:
+
+    const { foo, bar } = getContainer('services');
+
+The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
+the client version of the call is still accessiable:
+
+    const { foo, bar } = getContainer('services');
+    const { baz } = getContainer('services');
 
 ## Specifying Configs
 
@@ -78,28 +94,3 @@ These wrappers can be included by binding to the `serviceWrappers` container:
         [barWrapperConfig, barWrapper],
     ];
     bind('serviceConfig.additionalWrappers', serviceWrappers);
-
-## Import `bindServices`
-
-In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
-clients and config bindings have been bound.
-
-    import { bindServices } from '@globality/nodule-graphql';
-
-    import fooClients;
-    import barServiceConfig;
-
-    bindServices();
-
-## Using services
-
-The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
-simply replace the client getContainer call with a `services` get container call:
-
-    const { foo, bar } = getContainer('services');
-
-The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
-the client version of the call is still accessiable:
-
-    const { foo, bar } = getContainer('services');
-    const { baz } = getContainer('services');

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -13,15 +13,19 @@ The default name of `clients` can be used for the container or can be overridden
     });
     bind('clientsName', 'fooClients');
 
-## Specifying Configs
-
-There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
-In order to utilize these wrappers, configuration variables need to be bound.
+## Unique Key
 
 In order to generate a unique hashable key for a specific service request, a unique ID is used. To use any
 of the services, bind a specific UUID to `uniqueId`.
 
-    bind('uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
+    bind('serviceConfig.uniqueId', '5dfe05f8-59e3-4b07-ab21-7f221d75a83d');
+
+Alternatively the default uniqueId of '00000000-0000-0000-0000-000000000000' will be used.
+
+## Specifying Configs
+
+There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
+In order to utilize these wrappers, configuration variables need to be bound.
 
 The paths specified in the configurations should be retrievable from:
 
@@ -33,7 +37,7 @@ The paths specified in the configurations should be retrievable from:
         'path.to.foo.endpoint': {},
         'path.to.bar.endpoint': {},
     }
-    bind('dedupConfig', dedupConfig);
+    bind('serviceConfig.dedup', dedupConfig);
 
 ### batch
 
@@ -61,7 +65,7 @@ to be included during batched requests, the `assignArgs` parameter can be used.
             batchSearchRequest: named('path.to.bars.endpoint'),
         },
     }
-    bind('batchConfig', batchConfig);
+    bind('serviceConfig.batch', batchConfig);
 
 ## Additional wrappers
 
@@ -73,7 +77,7 @@ These wrappers can be included by binding to the `serviceWrappers` container:
         [fooWrapperConfig, fooWrapper],
         [barWrapperConfig, barWrapper],
     ];
-    bind('serviceWrappers', serviceWrappers);
+    bind('serviceConfig.additionalWrappers', serviceWrappers);
 
 ## Import `bindServices`
 

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -1,0 +1,398 @@
+import { get as mockGet } from 'lodash';
+import batched from '../wrapper';
+
+jest.mock('@globality/nodule-config', () => ({
+    getContainer: () => ({
+        config: {
+            performance: {
+                batchLimit: 3,
+            },
+        },
+    }),
+    getConfig: (lookup) => {
+        const config = {
+            concurrency: {
+                limit: 10,
+            },
+        };
+        return mockGet(config, lookup);
+    },
+}));
+
+let req;
+let companyRetrieve;
+let companySearch;
+let requestWrapper;
+let searchWrapper;
+
+
+describe('dataLoader requestWrapper', () => {
+    beforeEach(() => {
+        companyRetrieve = jest.fn(async (_, { id }) => ({ id }));
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.map(id => ({ id })),
+            count: companyIds.length,
+            offset: 0,
+            limit: 20,
+        }));
+        req = {
+            app: {
+                config: {
+                    performance: {
+                        batchLimit: 3,
+                    },
+                },
+            },
+        };
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+    });
+
+    it('should not batch 1 call', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should batch 2 calls', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should not batch 2 same call', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should batch 2 same calls + another different', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 5 calls to two batches', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 3 }),
+            requestWrapper(req, { id: 4 }),
+            requestWrapper(req, { id: 5 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(3);
+        expect(companies[3].id).toBe(4);
+        expect(companies[4].id).toBe(5);
+
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [4, 5],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 4 calls to batch + retrieve', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 3 }),
+            requestWrapper(req, { id: 4 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(3);
+        expect(companies[3].id).toBe(4);
+
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 4,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle assignArgs', async () => {
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+            assignArgs: [{ includeGhosts: true }],
+        });
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            includeGhosts: true,
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should raise for too many results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: [...companyIds.map(id => ({ id })), { id: 999 }],
+            count: companyIds.length + 1,
+            offset: 0,
+            limit: 20,
+        }));
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        let caughtError;
+        try {
+            expect(await Promise.all([
+                requestWrapper(req, { id: 999 }),
+                requestWrapper(req, { id: 1 }),
+            ])).toThrow();
+        } catch (thrownError) {
+            caughtError = thrownError;
+        }
+        expect(caughtError.message.message).toBe('Batching failed: expected to get one item but got too many results');
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should raise for no results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.filter(id => id !== -999).map(id => ({ id })),
+            count: companyIds.length - 1,
+            offset: 0,
+            limit: 20,
+        }));
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        let caughtError;
+        try {
+            expect(await Promise.all([
+                requestWrapper(req, { id: -999 }),
+                requestWrapper(req, { id: 1 }),
+            ])).toThrow();
+        } catch (thrownError) {
+            caughtError = thrownError;
+        }
+        expect(caughtError.message.message).toBe('Batching failed: expected to get one item but got none');
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [-999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle splitResponseBy', async () => {
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'idx',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            requestWrapper(req, { idx: 1 }),
+            requestWrapper(req, { idx: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 2 search calls', async () => {
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [1, 2] }),
+            searchWrapper(req, { companyIds: [2, 3] }),
+        ]);
+        expect(companies[0].count).toBe(2);
+        expect(companies[1].count).toBe(2);
+        expect(companies[0].items[0].id).toBe(1);
+        expect(companies[0].items[1].id).toBe(2);
+        expect(companies[1].items[0].id).toBe(2);
+        expect(companies[1].items[1].id).toBe(3);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle many search results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: [...companyIds.map(id => ({ id })), { id: 999 }],
+            count: companyIds.length + 1,
+            offset: 0,
+            limit: 20,
+        }));
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [999] }),
+            searchWrapper(req, { companyIds: [1] }),
+        ]);
+        expect(companies[0].count).toBe(2);
+        expect(companies[0].items[0].id).toBe(999);
+        expect(companies[0].items[1].id).toBe(999);
+        expect(companies[1].count).toBe(1);
+        expect(companies[1].items[0].id).toBe(1);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch handle missing search call', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.filter(id => id !== -999).map(id => ({ id })),
+            count: companyIds.length - 1,
+            offset: 0,
+            limit: 20,
+        }));
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [1] }),
+            searchWrapper(req, { companyIds: [-999] }),
+        ]);
+        expect(companies[0].items[0].id).toBe(1);
+        expect(companies[1].count).toBe(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, -999],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should not batch with offset parameter', async () => {
+        await Promise.all([
+            searchWrapper(req, { companyIds: [1], offset: 1 }),
+            searchWrapper(req, { companyIds: [2], offset: 1 }),
+        ]);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1],
+            offset: 1,
+        });
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [2],
+            offset: 1,
+        });
+    });
+
+    it('should not batch with limit > 1 parameter', async () => {
+        await Promise.all([
+            searchWrapper(req, { companyIds: [1], limit: 2 }),
+            searchWrapper(req, { companyIds: [2], limit: 2 }),
+        ]);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1],
+            limit: 2,
+        });
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [2],
+            limit: 2,
+        });
+    });
+
+    it('should batch with limit = 1 parameter', async () => {
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [999], limit: 1 }),
+            searchWrapper(req, { companyIds: [1], limit: 1 }),
+        ]);
+        expect(companies[0].items[0].id).toBe(999);
+        expect(companies[1].items[0].id).toBe(1);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+});

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -2,18 +2,13 @@ import { get as mockGet } from 'lodash';
 import batched from '../wrapper';
 
 jest.mock('@globality/nodule-config', () => ({
-    getContainer: (lookup) => {
-        if (lookup) {
-            return '00000000-0000-0000-0000-000000000000';
-        }
-        return {
-            config: {
-                performance: {
-                    batchLimit: 3,
-                },
+    getContainer: () => ({
+        config: {
+            performance: {
+                batchLimit: 3,
             },
-        };
-    },
+        },
+    }),
     getConfig: (lookup) => {
         const config = {
             concurrency: {

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -2,13 +2,18 @@ import { get as mockGet } from 'lodash';
 import batched from '../wrapper';
 
 jest.mock('@globality/nodule-config', () => ({
-    getContainer: () => ({
-        config: {
-            performance: {
-                batchLimit: 3,
+    getContainer: (lookup) => {
+        if (lookup) {
+            return '00000000-0000-0000-0000-000000000000';
+        }
+        return {
+            config: {
+                performance: {
+                    batchLimit: 3,
+                },
             },
-        },
-    }),
+        };
+    },
     getConfig: (lookup) => {
         const config = {
             concurrency: {

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -1,4 +1,5 @@
 import { get as mockGet } from 'lodash';
+import mockCreateKey from '../../core/keys';
 import batched from '../wrapper';
 
 const mockConfig = {
@@ -7,6 +8,7 @@ const mockConfig = {
             batchLimit: 3,
         },
     },
+    createKey: mockCreateKey,
 };
 jest.mock('@globality/nodule-config', () => ({
     bind: (key, value) => {

--- a/src/services/batching/batchRequests.js
+++ b/src/services/batching/batchRequests.js
@@ -1,0 +1,284 @@
+/*
+Optimization for calling similar microcosm requests at the same time
+This utility will reduce the amount of queries that styx creates by batching similar queries
+
+*/
+import { assign, chunk, chain, flatten, get, groupBy, omit, uniq } from 'lodash';
+import { NOT_FOUND, INTERNAL_SERVER_ERROR } from 'http-status-codes';
+import { getContainer } from '@globality/nodule-config';
+import { GraphQLError } from 'graphql';
+import { concurrentPaginate, all } from '../../modules';
+import createKey from '../core/keys';
+
+// Checks that a service request can be batched:
+// 1. Contains an accumulateBy value (such as userId)
+// 2. Does not contain offset parameter
+// 3. Does not contain limit>1 parameter
+function canArgsBeBatched(args, accumulateBy) {
+    return (
+        args[accumulateBy] !== undefined &&
+        args.offset === undefined &&
+        (args.limit === undefined || args.limit === 1)
+    );
+}
+
+// Split argsList to two argsLists:
+// List of args that can be batched (based on canArgsBeBatched)
+// List of args that cannot be batched
+function filterArgsToBatch(argsList, accumulateBy) {
+    const batchableArgsList = [];
+    const unBatchableArgsList = [];
+    argsList.forEach((args) => {
+        if (canArgsBeBatched(args, accumulateBy)) {
+            batchableArgsList.push(args);
+        } else {
+            unBatchableArgsList.push(args);
+        }
+    });
+    return { batchableArgsList, unBatchableArgsList };
+}
+
+// Separate argsList to chunks of argsList that can be batched.
+// Every group must:
+// 1. Contain no more than groupSize requests to batch
+// 2. Contain the same request args (except the batchArg arg)
+// Assumption: dont get the exact same args in the argsList
+// Example:
+// Input:
+//        argsList: [
+//           { userId: 1, event: FooEvent },
+//           { userId: 2, event: FooEvent },
+//           { userId: 2, event: BarEvent },
+//           { userId: 3, event: BarEvent },
+//        ]
+//        accumulateBy:   userId
+// Output:
+//  [
+//      [
+//          { userId: 1, event: FooEvent },
+//          { userId: 2, event: FooEvent },
+//      ],
+//      [
+//          { userId: 2, event: BarEvent },
+//          { userId: 3, event: BarEvent },
+//      ],
+//  ]
+function getArgsChunksList(req, argsList, accumulateBy) {
+    const argsGroups = groupBy(argsList, args => createKey(omit(args, accumulateBy)));
+    const { config } = getContainer();
+    const batchLimit = get(config, 'performance.batchLimit', 30);
+    return flatten(Object.keys(argsGroups).map(key => chunk(argsGroups[key], batchLimit)));
+}
+
+// Returns a (key(args): response) object (with one key) based on serviceRequest call and args
+// Example:
+// Input:
+//        args: { userId: 1, event: FooEvent }
+// Output:
+//        Promise() => {
+//            "{ userId: 1, event: FooEvent }": { count: 1, items: [...] }
+//         }
+async function resolveSimpleRequest(req, serviceRequest, args) {
+    const key = createKey(args);
+    const res = await serviceRequest(req, args).catch(error => ({ error }));
+    return { [key]: res };
+}
+
+// Batch argsLists
+// The input args must have the same request args (except the batchArg arg)
+//
+// Example:
+// Input:
+//        argsList: [
+//           { userId: 1, event: FooEvent },
+//           { userId: 1, event: BarEvent },
+//           { userId: 2, event: FooEvent },
+//           { userId: [3], event: FooEvent },
+//           { userId: [1, 4], event: FooEvent },
+//        ]
+//        accumulateBy:   userId
+//        accumulateInto: userIds
+//        assignArgs: [{ sourceType: unknown }]
+// Output:
+//        [
+//            { userIds: [1. 2, 3, 4], event: FooEvent, sourceType: unknown },
+//            { userIds: [1], event: BarEvent, sourceType: unknown },
+//        ]
+function batchRequestsArgs(argsList, { accumulateBy, accumulateInto, assignArgs = [{}] }) {
+    const batchedArgs = {
+        [accumulateInto]: uniq(flatten(argsList.map(args => args[accumulateBy]))),
+        ...omit(argsList[0], [accumulateBy, 'limit']),
+    };
+    return assign(batchedArgs, ...assignArgs);
+}
+
+function fakeResponse(items, fakeSearchResponse) {
+    if (fakeSearchResponse) {
+        if (!items) {
+            return {
+                count: 0,
+                items: [],
+                offset: 0,
+                limit: 0,
+            };
+        }
+        return {
+            count: items.length,
+            items,
+            offset: 0,
+            limit: items.length,
+        };
+    }
+    if (items.length === 0) {
+        return {
+            error: new GraphQLError({
+                message: 'Batching failed: expected to get one item but got none',
+                status: NOT_FOUND,
+            }),
+        };
+    }
+    if (items.length > 1) {
+        return {
+            error: new GraphQLError({
+                message: 'Batching failed: expected to get one item but got too many results',
+                status: INTERNAL_SERVER_ERROR,
+            }),
+        };
+    }
+    return items[0];
+}
+
+// Returns a (key(args): response) object (with more then key) based on batched searchRequest call
+//
+// Example:
+// Input:
+//        argsList: [
+//           { userId: 1, event: FooEvent },
+//           { userId: 2, event: FooEvent },
+//        ]
+//        accumulateBy:   userId
+//        accumulateInto: userIds
+//        splitResponseBy: groupId
+// Output:
+//        Promise() => {
+//            "{ userId: 1, event: FooEvent }": { count: 1, items: [...] }
+//            "{ userId: 2, event: FooEvent }": { count: 3, items: [...] }
+//         }
+async function resolveBatchRequest(
+    req,
+    {
+        requestsArgs,
+        searchRequest,
+        accumulateBy,
+        accumulateInto,
+        splitResponseBy,
+        assignArgs,
+        fakeSearchResponse,
+    },
+) {
+    // Batch many requests to a single search request
+    const batchedArgs = batchRequestsArgs(requestsArgs, {
+        accumulateBy,
+        accumulateInto,
+        assignArgs,
+    });
+
+    // Resolve it
+    // If error is raised, create many { error, id } items
+    const allResults = await all(req, { searchRequest, args: batchedArgs })
+        .catch(error => batchedArgs[accumulateInto].map(id => ({
+            error,
+            [splitResponseBy]: id,
+        })));
+    // Split the response by 'splitResponseBy'
+    const groupedResults = groupBy(allResults, splitResponseBy);
+    // Match the response items to the requests
+    const resultsBuckets = requestsArgs.reduce(
+        (acc, requestArgs) => ({
+            [createKey(requestArgs)]: chain([requestArgs[accumulateBy]])
+                .flatten()
+                .map(accumulateArg => groupedResults[accumulateArg])
+                .concat()
+                .flatten()
+                .compact()
+                .value(),
+            ...acc,
+        }),
+        {},
+    );
+    // Fake a microcosm response for every matched result.
+    return Object.keys(resultsBuckets).reduce(
+        (acc, key) => ({
+            [key]: fakeResponse(resultsBuckets[key], fakeSearchResponse),
+            ...acc,
+        }),
+        {},
+    );
+}
+
+// Resolve number of search requests at the same time
+// can batch some search requests into one.
+// argsList: list of search requests args (see caching.js)
+// searchRequest: async function that can resolve search requests (see caching.js)
+//  accumulateBy: the request arg that can be batch (for example: userId)
+//  accumulateInto: the request arg that accumulateBy arg can be merged into (for example: userIds)
+//  splitResponseBy: how to split the response for the batched request (should be same accumulateBy)
+// Return value: list of service responses ordered the same way as the args in argsList
+// Responses that should raise a service error (such as 404) - replaced by and object with
+// error key and value that should be thrown.
+export default async function batchRequests(
+    req,
+    {
+        argsList,
+        serviceRequest,
+        accumulateBy,
+        accumulateInto,
+        splitResponseBy = null,
+        assignArgs = [],
+        batchSearchRequest = null,
+        fakeSearchResponse = false,
+    },
+) {
+    const { batchableArgsList, unBatchableArgsList } = filterArgsToBatch(argsList, accumulateBy);
+    const argsChunksList = getArgsChunksList(req, batchableArgsList, accumulateBy);
+
+    // Dont batch:
+    // * Requests that cannot be batched
+    // * Requests that can be batched but with length 1
+    const argsListNotToBatch = [
+        ...unBatchableArgsList,
+        ...argsChunksList
+            .filter(argsChunks => argsChunks.length === 1)
+            .map(argsChunks => argsChunks[0]),
+    ];
+
+    // Batch
+    const argsListToBatch = argsChunksList.filter(argsChunks => argsChunks.length > 1);
+
+    // Create a search request promises based on argsList.
+    // Every promise will return an object with (str(args): response) items
+    // Use two different promises:
+    // * simple search requests
+    // * batch search requests
+    // (objects can have more then one keys if the requsts are batched)
+    const requestPromises = [
+        ...argsListNotToBatch.map(args => resolveSimpleRequest(req, serviceRequest, args)),
+        ...argsListToBatch.map(
+            argsChunks => resolveBatchRequest(req, {
+                requestsArgs: argsChunks,
+                searchRequest: batchSearchRequest || serviceRequest,
+                accumulateBy,
+                accumulateInto,
+                splitResponseBy: splitResponseBy || accumulateBy,
+                assignArgs,
+                fakeSearchResponse,
+            }),
+        ),
+    ];
+
+    const resonseObjects = await concurrentPaginate(requestPromises);
+
+    // Merge all responses to one (str(args) => response) object and arrange the response
+    const responsesObject = Object.assign(...resonseObjects);
+    return argsList.map(args => responsesObject[createKey(args)]);
+}

--- a/src/services/batching/wrapper.js
+++ b/src/services/batching/wrapper.js
@@ -1,17 +1,17 @@
 import { dedupMany } from '../dedup/wrapper';
 import batchRequests from './batchRequests';
 
-
-// In-request caching and batching wrapper
-// accumulateBy: the request arg that can be batch (example: userId)
-// accumulateInto: the request arg that accumulateBy arg can be merged into (example: userIds)
-// splitResponseBy: how to split the response for the batched request (default: accumulateBy)
-// batchSearchRequest: another serviceRequest that is used for batching
-//                     used when batching retrieve requests
-//                     for example (serviceRequest: userRetrieve, batchSearchRequest: userSearch)
-// assignArgs: additional args that will be included in the search request
-//             (example: [{ addFoo: true }])
-// loaderName: allows to access the DataLoader loader object with req.loaders.{loaderName}
+/* In-request caching and batching wrapper
+ * accumulateBy: the request arg that can be batch (example: userId)
+ * accumulateInto: the request arg that accumulateBy arg can be merged into (example: userIds)
+ * splitResponseBy: how to split the response for the batched request (default: accumulateBy)
+ * batchSearchRequest: another serviceRequest that is used for batching
+ *                     used when batching retrieve requests
+ *                     for example (serviceRequest: userRetrieve, batchSearchRequest: userSearch)
+ * assignArgs: additional args that will be included in the search request
+ *             (example: [{ addFoo: true }])
+ * loaderName: allows to access the DataLoader loader object with req.loaders.{loaderName}
+ */
 export default function batched(serviceRequest, {
     accumulateBy,
     accumulateInto,

--- a/src/services/batching/wrapper.js
+++ b/src/services/batching/wrapper.js
@@ -1,0 +1,43 @@
+import { dedupMany } from '../dedup/wrapper';
+import batchRequests from './batchRequests';
+
+
+// In-request caching and batching wrapper
+// accumulateBy: the request arg that can be batch (example: userId)
+// accumulateInto: the request arg that accumulateBy arg can be merged into (example: userIds)
+// splitResponseBy: how to split the response for the batched request (default: accumulateBy)
+// batchSearchRequest: another serviceRequest that is used for batching
+//                     used when batching retrieve requests
+//                     for example (serviceRequest: userRetrieve, batchSearchRequest: userSearch)
+// assignArgs: additional args that will be included in the search request
+//             (example: [{ addFoo: true }])
+// loaderName: allows to access the DataLoader loader object with req.loaders.{loaderName}
+export default function batched(serviceRequest, {
+    accumulateBy,
+    accumulateInto,
+    splitResponseBy = null,
+    assignArgs = [],
+    batchSearchRequest = null,
+    isSearchRequest = null,
+    loaderName = null,
+}) {
+    const fakeSearchResponse =
+          isSearchRequest === null ?
+              (batchSearchRequest === null) :
+              isSearchRequest;
+    const wrapper = (req, argsList) => (
+        argsList.length === 1 ?
+            Promise.all([serviceRequest(req, argsList[0])]) :
+            batchRequests(req, {
+                argsList,
+                serviceRequest,
+                batchSearchRequest,
+                accumulateBy,
+                accumulateInto,
+                splitResponseBy,
+                assignArgs,
+                fakeSearchResponse,
+            })
+    );
+    return dedupMany(wrapper, { loaderName, allowBatch: true });
+}

--- a/src/services/core/__tests__/keys.test.js
+++ b/src/services/core/__tests__/keys.test.js
@@ -5,31 +5,31 @@ describe('cacheKey', () => {
         expect(
             createKey('foo'),
         ).toEqual(
-            '9eb7791d-8309-59c6-8372-e5b9622dbbd8',
+            '1b942da9-3261-5084-a4cf-d80e559d5725',
         );
 
         expect(
             createKey('foo', 'bar'),
         ).toEqual(
-            'd4d7b595-10bb-57f0-ad65-8e7fc9cea49b',
+            'd74933fb-4f19-5a8d-9942-fd40364fb867',
         );
 
         expect(
             createKey(['foo'], 'bar'),
         ).toEqual(
-            'f8dab53c-ec03-5b1c-8bac-4925883069a2',
+            '5cc43b5a-1786-5981-b43a-93471a491f71',
         );
 
         expect(
             createKey({ foo: 'bar' }, 'bar'),
         ).toEqual(
-            '4c71c7bb-5c2b-5fab-9c73-571f1d07fc1d',
+            '2ee8d61c-b1d3-5b17-915b-4a8554a134ff',
         );
 
         expect(
             createKey({ foo: { bar: 'baz', qux: 'foo' } }),
         ).toEqual(
-            '2f81ca75-3eeb-5544-b806-6662a02ebf76',
+            '859609d5-0bf2-5960-a2b1-13b16111c21e',
         );
     });
 });

--- a/src/services/core/__tests__/keys.test.js
+++ b/src/services/core/__tests__/keys.test.js
@@ -5,31 +5,31 @@ describe('cacheKey', () => {
         expect(
             createKey('foo'),
         ).toEqual(
-            '9bf8a9db-8d02-5252-ab10-bb36d2cdd8b4',
+            '9eb7791d-8309-59c6-8372-e5b9622dbbd8',
         );
 
         expect(
             createKey('foo', 'bar'),
         ).toEqual(
-            '5a662f98-e6c6-57b5-bc34-a4130357ba35',
+            'd4d7b595-10bb-57f0-ad65-8e7fc9cea49b',
         );
 
         expect(
             createKey(['foo'], 'bar'),
         ).toEqual(
-            '958f1ae7-eb22-52a4-9a39-0d36a451f2b6',
+            'f8dab53c-ec03-5b1c-8bac-4925883069a2',
         );
 
         expect(
             createKey({ foo: 'bar' }, 'bar'),
         ).toEqual(
-            '63ac6f0b-fec8-57de-8133-f9e822af60b5',
+            '4c71c7bb-5c2b-5fab-9c73-571f1d07fc1d',
         );
 
         expect(
             createKey({ foo: { bar: 'baz', qux: 'foo' } }),
         ).toEqual(
-            '675e80b2-74d5-52b1-8523-05a0fa13c1d1',
+            '2f81ca75-3eeb-5544-b806-6662a02ebf76',
         );
     });
 });

--- a/src/services/core/__tests__/keys.test.js
+++ b/src/services/core/__tests__/keys.test.js
@@ -1,0 +1,36 @@
+import createKey from '../keys';
+
+describe('cacheKey', () => {
+    it('generates expected values', async () => {
+
+        expect(
+            createKey('foo'),
+        ).toEqual(
+            '8eadcea4-e7dc-5418-a8de-975fe703bfd4',
+        );
+
+        expect(
+            createKey('foo', 'bar'),
+        ).toEqual(
+            '7729fb23-462f-5cdf-a8a3-ec9989b7dfb3',
+        );
+
+        expect(
+            createKey(['foo'], 'bar'),
+        ).toEqual(
+            '8bcdfb19-8de4-5706-b724-8e0ea6acc028',
+        );
+
+        expect(
+            createKey({ foo: 'bar' }, 'bar'),
+        ).toEqual(
+            '19f12efd-29dd-5395-992f-c5398ba5fe5e',
+        );
+
+        expect(
+            createKey({ foo: { bar: 'baz', qux: 'foo' } }),
+        ).toEqual(
+            'cddeab82-584a-5ab4-b6c7-2e49de94d9b0',
+        );
+    });
+});

--- a/src/services/core/__tests__/keys.test.js
+++ b/src/services/core/__tests__/keys.test.js
@@ -2,35 +2,34 @@ import createKey from '../keys';
 
 describe('cacheKey', () => {
     it('generates expected values', async () => {
-
         expect(
             createKey('foo'),
         ).toEqual(
-            '8eadcea4-e7dc-5418-a8de-975fe703bfd4',
+            '9bf8a9db-8d02-5252-ab10-bb36d2cdd8b4',
         );
 
         expect(
             createKey('foo', 'bar'),
         ).toEqual(
-            '7729fb23-462f-5cdf-a8a3-ec9989b7dfb3',
+            '5a662f98-e6c6-57b5-bc34-a4130357ba35',
         );
 
         expect(
             createKey(['foo'], 'bar'),
         ).toEqual(
-            '8bcdfb19-8de4-5706-b724-8e0ea6acc028',
+            '958f1ae7-eb22-52a4-9a39-0d36a451f2b6',
         );
 
         expect(
             createKey({ foo: 'bar' }, 'bar'),
         ).toEqual(
-            '19f12efd-29dd-5395-992f-c5398ba5fe5e',
+            '63ac6f0b-fec8-57de-8133-f9e822af60b5',
         );
 
         expect(
             createKey({ foo: { bar: 'baz', qux: 'foo' } }),
         ).toEqual(
-            'cddeab82-584a-5ab4-b6c7-2e49de94d9b0',
+            '675e80b2-74d5-52b1-8523-05a0fa13c1d1',
         );
     });
 });

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -2,7 +2,7 @@ import { isObject, toPairs } from 'lodash';
 import { getContainer } from '@globality/nodule-config';
 import uuidv5 from 'uuid/v5';
 
-const uniqueId = getContainer('uniqueId');
+const uniqueId = getContainer('uniqueId') || '00000000-0000-0000-0000-000000000000';
 
 function valueToString(value) {
     if (Array.isArray(value)) {

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -26,7 +26,7 @@ const createKey = (args, keyName = '') => {
         key => `${key}=${valueToString(args[key])}`,
     ).join('&');
     const keyString = `${keyName}?${argsString}`;
-    return uuidv5(keyString, '694e1e91-283e-40d7-bf79-a91133627201');
+    return uuidv5(keyString, uuidv5.URL);
 };
 
 export default createKey;

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -1,8 +1,11 @@
-import { isObject, toPairs } from 'lodash';
+import { isObject, toPairs, get } from 'lodash';
 import { getContainer } from '@globality/nodule-config';
 import uuidv5 from 'uuid/v5';
 
-const uniqueId = getContainer('uniqueId') || '00000000-0000-0000-0000-000000000000';
+const DEFAULT_UNIQUE_ID = '00000000-0000-0000-0000-000000000000';
+const { serviceConfig } = getContainer();
+const uniqueId = get(serviceConfig, 'uniqueId') || DEFAULT_UNIQUE_ID;
+
 
 function valueToString(value) {
     if (Array.isArray(value)) {

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -1,0 +1,33 @@
+import { isObject, toPairs } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+import uuidv5 from 'uuid/v5';
+
+const uniqueId = getContainer('uniqueId');
+
+function valueToString(value) {
+    if (Array.isArray(value)) {
+        return value.sort().join(',');
+    }
+
+    if (isObject(value)) {
+        // returns a string like: "bar:baz,qux:foo"
+        return toPairs(value).map(pair => pair.join(':')).join(',');
+    }
+
+    return value;
+
+}
+
+
+/* Generate a hashable key for a specific service request.
+ *
+ * Used for batching, and deduplication.
+ *
+ */
+export default (args, strategyName = '') => {
+    const argsString = Object.keys(args).sort().map(
+        key => `${key}=${valueToString(args[key])}`,
+    ).join('&');
+    const keyString = `${strategyName}?${argsString}`;
+    return uuidv5(keyString, uniqueId);
+};

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -1,11 +1,5 @@
-import { isObject, toPairs, get } from 'lodash';
-import { getContainer } from '@globality/nodule-config';
+import { isObject, toPairs } from 'lodash';
 import uuidv5 from 'uuid/v5';
-
-const DEFAULT_UNIQUE_ID = '00000000-0000-0000-0000-000000000000';
-const { serviceConfig } = getContainer();
-const uniqueId = get(serviceConfig, 'uniqueId') || DEFAULT_UNIQUE_ID;
-
 
 function valueToString(value) {
     if (Array.isArray(value)) {
@@ -27,10 +21,12 @@ function valueToString(value) {
  * Used for batching, and deduplication.
  *
  */
-export default (args, strategyName = '') => {
+const createKey = (args, keyName = '') => {
     const argsString = Object.keys(args).sort().map(
         key => `${key}=${valueToString(args[key])}`,
     ).join('&');
-    const keyString = `${strategyName}?${argsString}`;
-    return uuidv5(keyString, uniqueId);
+    const keyString = `${keyName}?${argsString}`;
+    return uuidv5(keyString, '694e1e91-283e-40d7-bf79-a91133627201');
 };
+
+export default createKey;

--- a/src/services/core/named.js
+++ b/src/services/core/named.js
@@ -1,0 +1,15 @@
+import { get } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+
+
+/* Invoke a service via a named client.
+ */
+export default function named(serviceRequestName) {
+    const clientName = getContainer('clientsName');
+    const clients = getContainer(clientName || 'clients');
+    return (req, args) => get(
+        clients,
+        `${serviceRequestName}`,
+        (() => { throw Error(`${serviceRequestName} not implemented`); }),
+    )(req, args);
+}

--- a/src/services/core/named.js
+++ b/src/services/core/named.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import { getContainer } from '@globality/nodule-config';
-
+import { InternalServerError } from '../../errors';
 
 /* Invoke a service via a named client.
  */
@@ -10,6 +10,6 @@ export default function named(serviceRequestName) {
     return (req, args) => get(
         clients,
         `${serviceRequestName}`,
-        (() => { throw Error(`${serviceRequestName} not implemented`); }),
+        (() => { throw InternalServerError(`${serviceRequestName} not implemented`); }),
     )(req, args);
 }

--- a/src/services/core/named.js
+++ b/src/services/core/named.js
@@ -5,8 +5,8 @@ import { getContainer } from '@globality/nodule-config';
 /* Invoke a service via a named client.
  */
 export default function named(serviceRequestName) {
-    const clientName = getContainer('clientsName');
-    const clients = getContainer(clientName || 'clients');
+    const { clientsName } = getContainer();
+    const clients = getContainer(clientsName || 'clients');
     return (req, args) => get(
         clients,
         `${serviceRequestName}`,

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -1,15 +1,15 @@
 import dedup from '../wrapper';
+import mockCreateKey from '../../core/keys';
 
-let mockConfig = {};
+let mockConfig = {
+    createKey: mockCreateKey,
+};
 jest.mock('@globality/nodule-config', () => ({
     bind: (key, value) => {
         mockConfig[key] = value;
         return mockConfig;
     },
     getContainer: () => mockConfig,
-    clearBinding: () => {
-        mockConfig = {};
-    },
     getConfig: () => 10,
 }));
 
@@ -58,7 +58,9 @@ describe('dataLoader wrapper', () => {
         });
 
         // DataLoader api
-        mockConfig = {};
+        mockConfig = {
+            createKey: mockCreateKey,
+        };
 
         company = await wrapper(req, { id: 1 });
         expect(companyRetrieve).toHaveBeenCalledTimes(2);

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -1,0 +1,56 @@
+import dedup from '../wrapper';
+
+let req;
+let companyRetrieve;
+
+describe('dataLoader wrapper', () => {
+    beforeEach(() => {
+        companyRetrieve = jest.fn(async (_, { id }) => ({ id }));
+        req = {
+            app: {
+                config: {
+                },
+            },
+        };
+    });
+
+    it('should use in-req cache', async () => {
+        const wrapper = dedup(companyRetrieve, {});
+        let company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+
+        company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+
+        company = await wrapper(req, { id: 2 });
+        expect(company.id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(2);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 2,
+        });
+    });
+
+    it('should allow to access the loader object', async () => {
+        const wrapper = dedup(companyRetrieve, { loaderName: 'companyLoader' });
+        let company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+
+        // DataLoader api
+        req.loaders.companyLoader.clearAll();
+
+        company = await wrapper(req, { id: 1 });
+        expect(companyRetrieve).toHaveBeenCalledTimes(2);
+        expect(company.id).toBe(1);
+
+    });
+
+});

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -1,5 +1,18 @@
 import dedup from '../wrapper';
 
+let mockConfig = {};
+jest.mock('@globality/nodule-config', () => ({
+    bind: (key, value) => {
+        mockConfig[key] = value;
+        return mockConfig;
+    },
+    getContainer: () => mockConfig,
+    clearBinding: () => {
+        mockConfig = {};
+    },
+    getConfig: () => 10,
+}));
+
 let req;
 let companyRetrieve;
 
@@ -45,7 +58,7 @@ describe('dataLoader wrapper', () => {
         });
 
         // DataLoader api
-        req.loaders.companyLoader.clearAll();
+        mockConfig = {};
 
         company = await wrapper(req, { id: 1 });
         expect(companyRetrieve).toHaveBeenCalledTimes(2);

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -1,0 +1,80 @@
+/* Use DataLoader library for in-memory request deduplication.
+ *
+ * DataLoader consolidates all Promises for the same loader and input key
+ * during a single node "clock-tick", removing the need to evaluation some
+ * duplication requests.
+ *
+ * DataLoader does not do anything magic that spans multiple clock-ticks.
+ * Our own batching and caching are necessary in many cases.
+ */
+import DataLoader from 'dataloader';
+import uuidv4 from 'uuid/v4';
+import { get, set } from 'lodash';
+import { concurrentPaginate } from '../../modules';
+import createKey from '../core/keys';
+
+
+/* Fetch (and lazy-create) loaders by name.
+ *
+ * Loaders are cached on the request for re-use. Loaders are not shared
+ * across requests because of potential to violate access control policies
+ * between concurrent users.
+ */
+function getLoader(req, loaderId, loadMany, allowBatch) {
+    let loader = get(req, `loaders.${loaderId}`);
+    if (!loader) {
+        loader = new DataLoader(
+            argsList => loadMany(req, argsList),
+            {
+                // key uses a json like representation of ordered keys
+                // straight json would not work if parameters came in different order
+                cacheKeyFn: args => createKey(args),
+                batch: allowBatch,
+            },
+        );
+        set(req, `loaders.${loaderId}`, loader);
+    }
+    return loader;
+}
+
+
+/* Is a response object from a DataLoader function an errror (vs a BE result).
+ *
+ * An error object is an object with:
+ *   1. An error key (with Error as value)
+ *   2. An (optional) id key (such as id, userId, etc) and value
+ */
+function isError(object) {
+    return (object.error && Object.keys(object).length <= 2);
+}
+
+
+/* Wrapper that uses DataLoader for in-request de-duplication.
+ */
+export function dedupMany(loadMany, { loaderName, allowBatch = false }) {
+    const loaderId = loaderName || uuidv4();
+    // Fetch the loader in call time - (and in the req init)
+    return async (req, args) => getLoader(
+        req,
+        loaderId,
+        loadMany,
+        allowBatch,
+    ).load(args).then((res) => {
+        // special case - batch wrapper can an object with an error key to raise
+        if (isError(res)) {
+            throw res.error;
+        }
+        return res;
+    });
+}
+
+
+/* Wrapper that uses DataLoader for in-request de-duplication.
+ */
+export default function dedup(load, { loaderName }) {
+    const loadMany = async (req, argsList = []) => concurrentPaginate(
+        argsList.map(args => load(req, args)),
+    );
+
+    return dedupMany(loadMany, { loaderName });
+}

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -12,7 +12,6 @@ import uuidv4 from 'uuid/v4';
 import { get } from 'lodash';
 import { bind, getContainer } from '@globality/nodule-config';
 import { concurrentPaginate } from '../../modules';
-import createKey from '../core/keys';
 
 
 /* Fetch (and lazy-create) loaders by name.
@@ -23,6 +22,8 @@ import createKey from '../core/keys';
  */
 function getLoader(req, loaderId, loadMany, allowBatch) {
     const base = getContainer();
+    const { createKey } = getContainer();
+
     let loader = get(base, `loaders.${loaderId}`);
     if (!loader) {
         loader = new DataLoader(

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -9,7 +9,8 @@
  */
 import DataLoader from 'dataloader';
 import uuidv4 from 'uuid/v4';
-import { get, set } from 'lodash';
+import { get } from 'lodash';
+import { bind, getContainer } from '@globality/nodule-config';
 import { concurrentPaginate } from '../../modules';
 import createKey from '../core/keys';
 
@@ -21,7 +22,8 @@ import createKey from '../core/keys';
  * between concurrent users.
  */
 function getLoader(req, loaderId, loadMany, allowBatch) {
-    let loader = get(req, `loaders.${loaderId}`);
+    const base = getContainer();
+    let loader = get(base, `loaders.${loaderId}`);
     if (!loader) {
         loader = new DataLoader(
             argsList => loadMany(req, argsList),
@@ -32,7 +34,7 @@ function getLoader(req, loaderId, loadMany, allowBatch) {
                 batch: allowBatch,
             },
         );
-        set(req, `loaders.${loaderId}`, loader);
+        bind(`loaders.${loaderId}`, loader);
     }
     return loader;
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,33 @@
+import { get, set, cloneDeepWith } from 'lodash';
+import { bind, getContainer } from '@globality/nodule-config';
+import servicesWrappers from './wrapper';
+
+export function cloneClients(obj) {
+    return cloneDeepWith(obj, node => (
+        typeof node === 'function' ?
+            async (req, args) => node(req, args) :
+            Object.keys(node).reduce(
+                (acc, key) => ({ ...acc, [key]: cloneClients(node[key]) }),
+                {},
+            )
+    ));
+}
+
+function optimizeServices(services) {
+    Object.keys(servicesWrappers).forEach((requestName) => {
+        const serviceRequest = servicesWrappers[requestName];
+        if (get(services, requestName)) {
+            set(services, requestName, serviceRequest);
+        }
+    });
+}
+
+export function bindServices() {
+    const clientsName = getContainer('clientsName');
+    const clients = getContainer(clientsName || 'clients');
+    const services = cloneClients(clients);
+    optimizeServices(services);
+    Object.keys(services).forEach((clientName) => {
+        bind(`services.${clientName}`, () => services[clientName]);
+    });
+}

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,6 +1,7 @@
 import { cloneDeepWith } from 'lodash';
 import { bind, getContainer } from '@globality/nodule-config';
 import getServiceWrappers from './wrapper';
+import createKeyFunc from './core/keys';
 
 export function cloneClients(obj) {
     return cloneDeepWith(obj, node => (
@@ -26,6 +27,10 @@ function wrapClients(clients) {
 }
 
 export default function bindServices() {
+    const { createKey } = getContainer();
+    if (!createKey) {
+        bind('createKey', () => createKeyFunc);
+    }
     const { clientsName } = getContainer();
     const clients = getContainer(clientsName || 'clients');
     const services = wrapClients(clients);

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,6 +1,6 @@
 import { get, set, cloneDeepWith } from 'lodash';
 import { bind, getContainer } from '@globality/nodule-config';
-import servicesWrappers from './wrapper';
+import getServiceWrappers from './wrapper';
 
 export function cloneClients(obj) {
     return cloneDeepWith(obj, node => (
@@ -14,6 +14,7 @@ export function cloneClients(obj) {
 }
 
 function optimizeServices(services) {
+    const servicesWrappers = getServiceWrappers();
     Object.keys(servicesWrappers).forEach((requestName) => {
         const serviceRequest = servicesWrappers[requestName];
         if (get(services, requestName)) {
@@ -22,8 +23,8 @@ function optimizeServices(services) {
     });
 }
 
-export function bindServices() {
-    const clientsName = getContainer('clientsName');
+export default function bindServices() {
+    const { clientsName } = getContainer();
     const clients = getContainer(clientsName || 'clients');
     const services = cloneClients(clients);
     optimizeServices(services);

--- a/src/services/wrapper.js
+++ b/src/services/wrapper.js
@@ -1,0 +1,67 @@
+/* Wrap service calls by composing multiple wrapper functions.
+ *
+ * We support batching, caching, and (in-request) deduplication.
+ */
+import { flatten } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+
+import batched from './batching/wrapper';
+import deduped from './dedup/wrapper';
+import named from './core/named';
+
+function buildWrappers() {
+    const wrappers = [];
+
+    const dedupConfig = getContainer('dedupConfig');
+    if (dedupConfig) {
+        wrappers.append([dedupConfig, deduped]);
+    }
+
+    const batchConfig = getContainer('batchConfig');
+    if (batchConfig) {
+        wrappers.append([batchConfig, batched]);
+    }
+
+    const servicesWrappers = getContainer('serviceWrappers');
+    if (servicesWrappers) {
+        wrappers.extend(servicesWrappers);
+    }
+    return wrappers;
+}
+
+// NB: order matters here
+export const WRAPPERS = buildWrappers();
+
+
+// calculate the full list of service names that are wrapped
+export const WRAPPED_SERVICE_NAMES = Array.from(new Set(
+    flatten(
+        WRAPPERS.map(value => Object.keys(value[0])),
+    ),
+));
+
+
+/* Wrap a service call if args are defined.
+ */
+export function wrapIf(service, wrapper, args) {
+    return args ? wrapper(service, args) : service;
+}
+
+
+/* Wrap a single service call.
+ */
+export function wrap(name) {
+    return WRAPPERS.reduce(
+        (service, [config, wrapper]) => wrapIf(service, wrapper, config[name]),
+        named(name),
+    );
+}
+
+
+const servicesWrappers = Object.assign(
+    {},
+    ...WRAPPED_SERVICE_NAMES.map(name => ({ [name]: wrap(name) })),
+);
+
+
+export default servicesWrappers;

--- a/src/services/wrapper.js
+++ b/src/services/wrapper.js
@@ -51,7 +51,7 @@ function getServiceWrappers() {
     const wrappers = buildWrappers();
 
     // calculate the full list of service names that are wrapped
-    const WRAPPED_SERVICE_NAMES = Array.from(new Set(
+    const wrappedServiceNames = Array.from(new Set(
         flatten(
             wrappers.map(value => Object.keys(value[0])),
         ),
@@ -59,7 +59,7 @@ function getServiceWrappers() {
 
     return Object.assign(
         {},
-        ...WRAPPED_SERVICE_NAMES.map(name => ({ [name]: wrap(wrappers, name) })),
+        ...wrappedServiceNames.map(name => ({ [name]: wrap(wrappers, name) })),
     );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5002,7 +5006,7 @@ uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@^3.1.0:
+uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
* Includes batching and dedup functionality
* Supports adding more wrappers

Why?

There is a need to wrap OpenAPIClient definitions to inject additional functionality around all endpoints.