### PR TITLE
Add services support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0
+current_version = 0.21.0
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Resolvers should throw errors when something fails. Within `nodule-graphql`, it 
  -  Most errors will borrow from HTTP error codes (because they have well-known, useful semantics)
  -  Error codes should be visible to API consumers via `error.extensions`
 
+## Services
+
+`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all
+defined endpoints.
+
+For usage see the README in the services folder.
 
 ## Local Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "babel src --out-dir lib --ignore '**/__tests__/*,**/__mocks__/*'",
         "lint": "eslint src --cache",
-        "test": "jest src",
+        "test": "jest",
         "verify": "yarn lint && yarn test"
     },
     "dependencies": {
@@ -17,6 +17,7 @@
         "axios": "^0.18.0",
         "connect-requestid": "^1.1.0",
         "cors": "^2.8.4",
+        "dataloader": "^1.4.0",
         "express": "^4.16.3",
         "express-jwt": "^5.3.1",
         "helmet": "^3.12.0",
@@ -24,6 +25,7 @@
         "jsonwebtoken": "^8.2.0",
         "lodash": "^4.17.5",
         "throat": "^4.1.0",
+        "uuid": "^3.2.1",
         "yarn": "^1.5.1"
     },
     "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -34,3 +34,4 @@ export {
     signPrivate,
 } from './testing';
 export { wrapResolvers } from './wrapper';
+export { default as bindServices } from './services';

--- a/src/modules/concurrency.js
+++ b/src/modules/concurrency.js
@@ -12,7 +12,6 @@ function getConcurrency(concurrencyLimit) {
     if (!isNil(concurrencyLimit)) {
         return concurrencyLimit;
     }
-
     return parseInt(getConfig('concurrency.limit') || DEFAULT_CONCURRENCY, 10);
 }
 

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,109 @@
+# Services
+
+`nodule-graphql` allows you to wrap your OpenAPI client implementations to add modifications to all
+defined endpoints.
+
+## OpenAPI Clients Container Name
+
+All of OpenAPI clients that are to be converted into wrapped services need to be bound to a container.
+The default name of `clients` can be used for the container or can be overridden by binding to `clientsName`:
+
+    Object.keys(specs).forEach((name) => {
+        bind(`fooClients.${name}`, () => createOpenAPIClient(name, specs[name]));
+    });
+    bind('clientsName', 'fooClients');
+
+## Import `bindServices`
+
+In the application defintion import 'bindServices' from `nodule-graphql` and call it once all of the 
+clients and config bindings have been bound.
+
+    import { bindServices } from '@globality/nodule-graphql';
+
+    import fooClients;
+    import barServiceConfig;
+
+    bindServices();
+
+## Using services
+
+The wrapped services will be bound to the `services` field. In order to use the wrapped clients, 
+simply replace the client getContainer call with a `services` get container call:
+
+    const { foo, bar } = getContainer('services');
+
+The original `clients` are still bound so if for a specific endpoint, the services are not desired, 
+the client version of the call is still accessiable:
+
+    const { foo, bar } = getContainer('services');
+    const { baz } = getContainer('services');
+
+## Specifying Configs
+
+There are 2 base wrappers included in `nodule-graphql`: batching and deduplication.
+In order to utilize these wrappers, configuration variables need to be bound.
+
+The paths specified in the configurations should be retrievable from:
+
+    getContainer(`{clientsName}.{path}`)
+
+### dedup
+
+    const dedupConfig = {
+        'path.to.foo.endpoint': {},
+        'path.to.bar.endpoint': {},
+    }
+    bind('serviceConfig.dedup', dedupConfig);
+
+### batch
+
+For a given path the `accumulateBy` and `accumulateInto` should include a field that can be grouped
+into a different parameter to be passed into the same endpoint. In addition the returned response
+must include the `accumulateBy` field as one of the properties. If it doesnt, specify a `splitResponseBy`
+field to split the returned response by. If the batched endpoint is different than the original
+request, this can be specified with `batchSearchRequest` field. Finally if specific parameters need
+to be included during batched requests, the `assignArgs` parameter can be used.
+
+    const batchConfig = {
+        'path.to.foo.endpoint': {
+            accumulateBy: 'foo',
+            accumulateInto: 'foos',
+        },
+        'path.to.bar.endpoint': {
+            accumulateBy: 'bar',
+            accumulateInto: 'bars',
+            splitResponseBy: 'baz',
+            assignArgs: [
+                {
+                    additionParameter: 'parameter',
+                },
+            ],
+            batchSearchRequest: named('path.to.bars.endpoint'),
+        },
+    }
+    bind('serviceConfig.batch', batchConfig);
+
+## Additional wrappers
+
+`nodule-graphql` also supports including additional wrappers. All wrappers should be written in a way 
+to expect (req, args) parameters, and only operate on endpoints specified in an associated config.
+
+These wrappers can be included by binding to the `serviceWrappers` container:
+    const serviceWrappers = [
+        [fooWrapperConfig, fooWrapper],
+        [barWrapperConfig, barWrapper],
+    ];
+    bind('serviceConfig.additionalWrappers', serviceWrappers);
+
+## Override createKey
+
+`nodule-graphql` generates a unique key to be used for batching/deduplication. The library allows
+the ability to override this function. The function should be able to generate a unique key given
+a list of arguments.
+
+    function createKey(args) {
+        ... calculate key based on args ...
+        return key;
+    }
+
+    bind('createKey', () => createKey);

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -1,0 +1,399 @@
+import { get as mockGet } from 'lodash';
+import mockCreateKey from '../../core/keys';
+import batched from '../wrapper';
+
+const mockConfig = {
+    config: {
+        performance: {
+            batchLimit: 3,
+        },
+    },
+    createKey: mockCreateKey,
+};
+jest.mock('@globality/nodule-config', () => ({
+    bind: (key, value) => {
+        mockConfig[key] = value;
+        return mockConfig;
+    },
+    getContainer: () => (mockConfig),
+    getConfig: (lookup) => {
+        const config = {
+            concurrency: {
+                limit: 10,
+            },
+        };
+        return mockGet(config, lookup);
+    },
+}));
+
+let req;
+let companyRetrieve;
+let companySearch;
+let requestWrapper;
+let searchWrapper;
+
+
+describe('dataLoader requestWrapper', () => {
+    beforeEach(() => {
+        companyRetrieve = jest.fn(async (_, { id }) => ({ id }));
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.map(id => ({ id })),
+            count: companyIds.length,
+            offset: 0,
+            limit: 20,
+        }));
+        req = {
+            app: {},
+        };
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+    });
+
+    it('should not batch 1 call', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should batch 2 calls', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should not batch 2 same call', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should batch 2 same calls + another different', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 1 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 5 calls to two batches', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 3 }),
+            requestWrapper(req, { id: 4 }),
+            requestWrapper(req, { id: 5 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(3);
+        expect(companies[3].id).toBe(4);
+        expect(companies[4].id).toBe(5);
+
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [4, 5],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 4 calls to batch + retrieve', async () => {
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+            requestWrapper(req, { id: 3 }),
+            requestWrapper(req, { id: 4 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companies[2].id).toBe(3);
+        expect(companies[3].id).toBe(4);
+
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 4,
+        });
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle assignArgs', async () => {
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+            assignArgs: [{ includeGhosts: true }],
+        });
+        const companies = await Promise.all([
+            requestWrapper(req, { id: 1 }),
+            requestWrapper(req, { id: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            includeGhosts: true,
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should raise for too many results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: [...companyIds.map(id => ({ id })), { id: 999 }],
+            count: companyIds.length + 1,
+            offset: 0,
+            limit: 20,
+        }));
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        let caughtError;
+        try {
+            expect(await Promise.all([
+                requestWrapper(req, { id: 999 }),
+                requestWrapper(req, { id: 1 }),
+            ])).toThrow();
+        } catch (thrownError) {
+            caughtError = thrownError;
+        }
+        expect(caughtError.message).toBe('Batching failed: expected to get one item but got too many results');
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should raise for no results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.filter(id => id !== -999).map(id => ({ id })),
+            count: companyIds.length - 1,
+            offset: 0,
+            limit: 20,
+        }));
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'id',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+        });
+        let caughtError;
+        try {
+            expect(await Promise.all([
+                requestWrapper(req, { id: -999 }),
+                requestWrapper(req, { id: 1 }),
+            ])).toThrow();
+        } catch (thrownError) {
+            caughtError = thrownError;
+        }
+        expect(caughtError.message).toBe('Batching failed: expected to get one item but got none');
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [-999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle splitResponseBy', async () => {
+        requestWrapper = batched(companyRetrieve, {
+            accumulateBy: 'idx',
+            accumulateInto: 'companyIds',
+            batchSearchRequest: companySearch,
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            requestWrapper(req, { idx: 1 }),
+            requestWrapper(req, { idx: 2 }),
+        ]);
+        expect(companies[0].id).toBe(1);
+        expect(companies[1].id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch 2 search calls', async () => {
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [1, 2] }),
+            searchWrapper(req, { companyIds: [2, 3] }),
+        ]);
+        expect(companies[0].count).toBe(2);
+        expect(companies[1].count).toBe(2);
+        expect(companies[0].items[0].id).toBe(1);
+        expect(companies[0].items[1].id).toBe(2);
+        expect(companies[1].items[0].id).toBe(2);
+        expect(companies[1].items[1].id).toBe(3);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, 2, 3],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should handle many search results', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: [...companyIds.map(id => ({ id })), { id: 999 }],
+            count: companyIds.length + 1,
+            offset: 0,
+            limit: 20,
+        }));
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [999] }),
+            searchWrapper(req, { companyIds: [1] }),
+        ]);
+        expect(companies[0].count).toBe(2);
+        expect(companies[0].items[0].id).toBe(999);
+        expect(companies[0].items[1].id).toBe(999);
+        expect(companies[1].count).toBe(1);
+        expect(companies[1].items[0].id).toBe(1);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should batch handle missing search call', async () => {
+        companySearch = jest.fn(async (_, { companyIds }) => ({
+            items: companyIds.filter(id => id !== -999).map(id => ({ id })),
+            count: companyIds.length - 1,
+            offset: 0,
+            limit: 20,
+        }));
+        searchWrapper = batched(companySearch, {
+            accumulateBy: 'companyIds',
+            accumulateInto: 'companyIds',
+            splitResponseBy: 'id',
+        });
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [1] }),
+            searchWrapper(req, { companyIds: [-999] }),
+        ]);
+        expect(companies[0].items[0].id).toBe(1);
+        expect(companies[1].count).toBe(0);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenLastCalledWith(req, {
+            companyIds: [1, -999],
+            limit: 20,
+            offset: 0,
+        });
+    });
+
+    it('should not batch with offset parameter', async () => {
+        await Promise.all([
+            searchWrapper(req, { companyIds: [1], offset: 1 }),
+            searchWrapper(req, { companyIds: [2], offset: 1 }),
+        ]);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1],
+            offset: 1,
+        });
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [2],
+            offset: 1,
+        });
+    });
+
+    it('should not batch with limit > 1 parameter', async () => {
+        await Promise.all([
+            searchWrapper(req, { companyIds: [1], limit: 2 }),
+            searchWrapper(req, { companyIds: [2], limit: 2 }),
+        ]);
+        expect(companySearch).toHaveBeenCalledTimes(2);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [1],
+            limit: 2,
+        });
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [2],
+            limit: 2,
+        });
+    });
+
+    it('should batch with limit = 1 parameter', async () => {
+        const companies = await Promise.all([
+            searchWrapper(req, { companyIds: [999], limit: 1 }),
+            searchWrapper(req, { companyIds: [1], limit: 1 }),
+        ]);
+        expect(companies[0].items[0].id).toBe(999);
+        expect(companies[1].items[0].id).toBe(1);
+        expect(companySearch).toHaveBeenCalledTimes(1);
+        expect(companySearch).toHaveBeenCalledWith(req, {
+            companyIds: [999, 1],
+            limit: 20,
+            offset: 0,
+        });
+    });
+});

--- a/src/services/batching/batchRequests.js
+++ b/src/services/batching/batchRequests.js
@@ -1,0 +1,289 @@
+/*
+ *  Optimization for calling similar microcosm requests at the same time
+ *  This utility will reduce the amount of queries that styx creates by batching similar queries
+ */
+import { assign, chunk, chain, flatten, get, groupBy, omit, uniq } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+import { NotFound, InternalServerError } from '../../errors';
+import { concurrentPaginate, all } from '../../modules';
+
+/* Checks that a service request can be batched:
+ * 1. Contains an accumulateBy value (such as userId)
+ * 2. Does not contain offset parameter
+ * 3. Does not contain limit>1 parameter
+ */
+function canArgsBeBatched(args, accumulateBy) {
+    return (
+        args[accumulateBy] !== undefined &&
+        args.offset === undefined &&
+        (args.limit === undefined || args.limit === 1)
+    );
+}
+
+/* Split argsList to two argsLists:
+ * List of args that can be batched (based on canArgsBeBatched)
+ * List of args that cannot be batched
+ */
+function filterArgsToBatch(argsList, accumulateBy) {
+    const batchableArgsList = [];
+    const unBatchableArgsList = [];
+    argsList.forEach((args) => {
+        if (canArgsBeBatched(args, accumulateBy)) {
+            batchableArgsList.push(args);
+        } else {
+            unBatchableArgsList.push(args);
+        }
+    });
+    return { batchableArgsList, unBatchableArgsList };
+}
+
+/* Separate argsList to chunks of argsList that can be batched.
+ * Every group must:
+ *     1. Contain no more than groupSize requests to batch
+ *     2. Contain the same request args (except the batchArg arg)
+ * Assumption: dont get the exact same args in the argsList
+ * Example:
+ * Input:
+ *     argsList: [
+ *         { userId: 1, event: FooEvent },
+ *         { userId: 2, event: FooEvent },
+ *         { userId: 2, event: BarEvent },
+ *         { userId: 3, event: BarEvent },
+ *     ]
+ *     accumulateBy:   userId
+ * Output:
+ * [
+ *     [
+ *         { userId: 1, event: FooEvent },
+ *         { userId: 2, event: FooEvent },
+ *     ],
+ *     [
+ *         { userId: 2, event: BarEvent },
+ *         { userId: 3, event: BarEvent },
+ *     ],
+ * ]
+ */
+function getArgsChunksList(req, argsList, accumulateBy) {
+    const { createKey, config } = getContainer();
+    const argsGroups = groupBy(argsList, args => createKey(omit(args, accumulateBy)));
+    const batchLimit = get(config, 'performance.batchLimit', 30);
+    return flatten(Object.keys(argsGroups).map(key => chunk(argsGroups[key], batchLimit)));
+}
+
+/*  Returns a (key(args): response) object (with one key) based on serviceRequest call and args
+ *  Example:
+ *  Input:
+ *      args: { userId: 1, event: FooEvent }
+ *  Output:
+ *      Promise() => {
+ *          "{ userId: 1, event: FooEvent }": { count: 1, items: [...] }
+ *          }
+ */
+async function resolveSimpleRequest(req, serviceRequest, args) {
+    const { createKey } = getContainer();
+    const key = createKey(args);
+    const res = await serviceRequest(req, args).catch(error => ({ error }));
+    return { [key]: res };
+}
+
+/*  Batch argsLists
+ *  The input args must have the same request args (except the batchArg arg)
+ *  Example:
+ *  Input:
+ *      argsList: [
+ *          { userId: 1, event: FooEvent },
+ *          { userId: 1, event: BarEvent },
+ *          { userId: 2, event: FooEvent },
+ *          { userId: [3], event: FooEvent },
+ *          { userId: [1, 4], event: FooEvent },
+ *      ]
+ *      accumulateBy:   userId
+ *      accumulateInto: userIds
+ *      assignArgs: [{ sourceType: unknown }]
+ *  Output:
+ *      [
+ *          { userIds: [1. 2, 3, 4], event: FooEvent, sourceType: unknown },
+ *          { userIds: [1], event: BarEvent, sourceType: unknown },
+ *      ]
+ */
+function batchRequestsArgs(argsList, { accumulateBy, accumulateInto, assignArgs = [{}] }) {
+    const batchedArgs = {
+        [accumulateInto]: uniq(flatten(argsList.map(args => args[accumulateBy]))),
+        ...omit(argsList[0], [accumulateBy, 'limit']),
+    };
+    return assign(batchedArgs, ...assignArgs);
+}
+
+function fakeResponse(items, fakeSearchResponse) {
+    if (fakeSearchResponse) {
+        if (!items) {
+            return {
+                count: 0,
+                items: [],
+                offset: 0,
+                limit: 0,
+            };
+        }
+        return {
+            count: items.length,
+            items,
+            offset: 0,
+            limit: items.length,
+        };
+    }
+    if (items.length === 0) {
+        return {
+            error: new NotFound(
+                'Batching failed: expected to get one item but got none',
+            ),
+        };
+    }
+    if (items.length > 1) {
+        return {
+            error: new InternalServerError(
+                'Batching failed: expected to get one item but got too many results',
+            ),
+        };
+    }
+    return items[0];
+}
+
+/* Returns a (key(args): response) object (with more then key) based on batched searchRequest call
+ * Example:
+ * Input:
+ *     argsList: [
+ *         { userId: 1, event: FooEvent },
+ *         { userId: 2, event: FooEvent },
+ *     ]
+ *     accumulateBy:   userId
+ *     accumulateInto: userIds
+ *     splitResponseBy: groupId
+ * Output:
+ *     Promise() => {
+ *         "{ userId: 1, event: FooEvent }": { count: 1, items: [...] }
+ *         "{ userId: 2, event: FooEvent }": { count: 3, items: [...] }
+ *         }
+ */
+async function resolveBatchRequest(
+    req,
+    {
+        requestsArgs,
+        searchRequest,
+        accumulateBy,
+        accumulateInto,
+        splitResponseBy,
+        assignArgs,
+        fakeSearchResponse,
+    },
+) {
+    /* Batch many requests to a single search request
+     */
+    const batchedArgs = batchRequestsArgs(requestsArgs, {
+        accumulateBy,
+        accumulateInto,
+        assignArgs,
+    });
+
+    /* Resolve it
+     * If error is raised, create many { error, id } items
+     */
+    const allResults = await all(req, { searchRequest, args: batchedArgs })
+        .catch(error => batchedArgs[accumulateInto].map(id => ({
+            error,
+            [splitResponseBy]: id,
+        })));
+    // Split the response by 'splitResponseBy'
+    const groupedResults = groupBy(allResults, splitResponseBy);
+    const { createKey } = getContainer();
+    // Match the response items to the requests
+    const resultsBuckets = requestsArgs.reduce(
+        (acc, requestArgs) => ({
+            [createKey(requestArgs)]: chain([requestArgs[accumulateBy]])
+                .flatten()
+                .map(accumulateArg => groupedResults[accumulateArg])
+                .concat()
+                .flatten()
+                .compact()
+                .value(),
+            ...acc,
+        }),
+        {},
+    );
+    // Fake a microcosm response for every matched result.
+    return Object.keys(resultsBuckets).reduce(
+        (acc, key) => ({
+            [key]: fakeResponse(resultsBuckets[key], fakeSearchResponse),
+            ...acc,
+        }),
+        {},
+    );
+}
+
+
+/* Resolve number of search requests at the same time can batch some search requests into one.
+ *     argsList: list of search requests args (see caching.js)
+ *     searchRequest: async function that can resolve search requests (see caching.js)
+ *     accumulateBy: the request arg that can be batch (for example: userId)
+ *     accumulateInto: the request arg that accumulateBy can be merged into (eg: userIds)
+ *     splitResponseBy: split the response for the batched request (should be same accumulateBy)
+ * Return value: list of service responses ordered the same way as the args in argsList
+ * Responses that should raise a service error (such as 404) - replaced by and object with
+ * error key and value that should be thrown.
+ */
+export default async function batchRequests(
+    req,
+    {
+        argsList,
+        serviceRequest,
+        accumulateBy,
+        accumulateInto,
+        splitResponseBy = null,
+        assignArgs = [],
+        batchSearchRequest = null,
+        fakeSearchResponse = false,
+    },
+) {
+    const { batchableArgsList, unBatchableArgsList } = filterArgsToBatch(argsList, accumulateBy);
+    const argsChunksList = getArgsChunksList(req, batchableArgsList, accumulateBy);
+
+    // Dont batch:
+    // * Requests that cannot be batched
+    // * Requests that can be batched but with length 1
+    const argsListNotToBatch = [
+        ...unBatchableArgsList,
+        ...argsChunksList
+            .filter(argsChunks => argsChunks.length === 1)
+            .map(argsChunks => argsChunks[0]),
+    ];
+
+    // Batch
+    const argsListToBatch = argsChunksList.filter(argsChunks => argsChunks.length > 1);
+
+    /* Create a search request promises based on argsList.
+     * Every promise will return an object with (str(args): response) items
+     * Use two different promises:
+     *  * simple search requests
+     *  * batch search requests
+     * (objects can have more then one key if the requsts are batched)
+     */
+    const requestPromises = [
+        ...argsListNotToBatch.map(args => resolveSimpleRequest(req, serviceRequest, args)),
+        ...argsListToBatch.map(
+            argsChunks => resolveBatchRequest(req, {
+                requestsArgs: argsChunks,
+                searchRequest: batchSearchRequest || serviceRequest,
+                accumulateBy,
+                accumulateInto,
+                splitResponseBy: splitResponseBy || accumulateBy,
+                assignArgs,
+                fakeSearchResponse,
+            }),
+        ),
+    ];
+
+    const resonseObjects = await concurrentPaginate(requestPromises);
+    const { createKey } = getContainer();
+    // Merge all responses to one (str(args) => response) object and arrange the response
+    const responsesObject = Object.assign(...resonseObjects);
+    return argsList.map(args => responsesObject[createKey(args)]);
+}

--- a/src/services/batching/wrapper.js
+++ b/src/services/batching/wrapper.js
@@ -1,0 +1,43 @@
+import { dedupMany } from '../dedup/wrapper';
+import batchRequests from './batchRequests';
+
+/* In-request caching and batching wrapper
+ * accumulateBy: the request arg that can be batch (example: userId)
+ * accumulateInto: the request arg that accumulateBy arg can be merged into (example: userIds)
+ * splitResponseBy: how to split the response for the batched request (default: accumulateBy)
+ * batchSearchRequest: another serviceRequest that is used for batching
+ *                     used when batching retrieve requests
+ *                     for example (serviceRequest: userRetrieve, batchSearchRequest: userSearch)
+ * assignArgs: additional args that will be included in the search request
+ *             (example: [{ addFoo: true }])
+ * loaderName: allows to access the DataLoader loader object with req.loaders.{loaderName}
+ */
+export default function batched(serviceRequest, {
+    accumulateBy,
+    accumulateInto,
+    splitResponseBy = null,
+    assignArgs = [],
+    batchSearchRequest = null,
+    isSearchRequest = null,
+    loaderName = null,
+}) {
+    const fakeSearchResponse =
+          isSearchRequest === null ?
+              (batchSearchRequest === null) :
+              isSearchRequest;
+    const wrapper = (req, argsList) => (
+        argsList.length === 1 ?
+            Promise.all([serviceRequest(req, argsList[0])]) :
+            batchRequests(req, {
+                argsList,
+                serviceRequest,
+                batchSearchRequest,
+                accumulateBy,
+                accumulateInto,
+                splitResponseBy,
+                assignArgs,
+                fakeSearchResponse,
+            })
+    );
+    return dedupMany(wrapper, { loaderName, allowBatch: true });
+}

--- a/src/services/core/__tests__/keys.test.js
+++ b/src/services/core/__tests__/keys.test.js
@@ -1,0 +1,35 @@
+import createKey from '../keys';
+
+describe('cacheKey', () => {
+    it('generates expected values', async () => {
+        expect(
+            createKey('foo'),
+        ).toEqual(
+            '1b942da9-3261-5084-a4cf-d80e559d5725',
+        );
+
+        expect(
+            createKey('foo', 'bar'),
+        ).toEqual(
+            'd74933fb-4f19-5a8d-9942-fd40364fb867',
+        );
+
+        expect(
+            createKey(['foo'], 'bar'),
+        ).toEqual(
+            '5cc43b5a-1786-5981-b43a-93471a491f71',
+        );
+
+        expect(
+            createKey({ foo: 'bar' }, 'bar'),
+        ).toEqual(
+            '2ee8d61c-b1d3-5b17-915b-4a8554a134ff',
+        );
+
+        expect(
+            createKey({ foo: { bar: 'baz', qux: 'foo' } }),
+        ).toEqual(
+            '859609d5-0bf2-5960-a2b1-13b16111c21e',
+        );
+    });
+});

--- a/src/services/core/keys.js
+++ b/src/services/core/keys.js
@@ -1,0 +1,32 @@
+import { isObject, toPairs } from 'lodash';
+import uuidv5 from 'uuid/v5';
+
+function valueToString(value) {
+    if (Array.isArray(value)) {
+        return value.sort().join(',');
+    }
+
+    if (isObject(value)) {
+        // returns a string like: "bar:baz,qux:foo"
+        return toPairs(value).map(pair => pair.join(':')).join(',');
+    }
+
+    return value;
+
+}
+
+
+/* Generate a hashable key for a specific service request.
+ *
+ * Used for batching, and deduplication.
+ *
+ */
+const createKey = (args, keyName = '') => {
+    const argsString = Object.keys(args).sort().map(
+        key => `${key}=${valueToString(args[key])}`,
+    ).join('&');
+    const keyString = `${keyName}?${argsString}`;
+    return uuidv5(keyString, uuidv5.URL);
+};
+
+export default createKey;

--- a/src/services/core/named.js
+++ b/src/services/core/named.js
@@ -1,0 +1,15 @@
+import { get } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+import { InternalServerError } from '../../errors';
+
+/* Invoke a service via a named client.
+ */
+export default function named(serviceRequestName) {
+    const { clientsName } = getContainer();
+    const clients = getContainer(clientsName || 'clients');
+    return (req, args) => get(
+        clients,
+        `${serviceRequestName}`,
+        (() => { throw InternalServerError(`${serviceRequestName} not implemented`); }),
+    )(req, args);
+}

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -1,0 +1,71 @@
+import dedup from '../wrapper';
+import mockCreateKey from '../../core/keys';
+
+let mockConfig = {
+    createKey: mockCreateKey,
+};
+jest.mock('@globality/nodule-config', () => ({
+    bind: (key, value) => {
+        mockConfig[key] = value;
+        return mockConfig;
+    },
+    getContainer: () => mockConfig,
+    getConfig: () => 10,
+}));
+
+let req;
+let companyRetrieve;
+
+describe('dataLoader wrapper', () => {
+    beforeEach(() => {
+        companyRetrieve = jest.fn(async (_, { id }) => ({ id }));
+        req = {
+            app: {
+                config: {
+                },
+            },
+        };
+    });
+
+    it('should use in-req cache', async () => {
+        const wrapper = dedup(companyRetrieve, {});
+        let company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+
+        company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+
+        company = await wrapper(req, { id: 2 });
+        expect(company.id).toBe(2);
+        expect(companyRetrieve).toHaveBeenCalledTimes(2);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 2,
+        });
+    });
+
+    it('should allow to access the loader object', async () => {
+        const wrapper = dedup(companyRetrieve, { loaderName: 'companyLoader' });
+        let company = await wrapper(req, { id: 1 });
+        expect(company.id).toBe(1);
+        expect(companyRetrieve).toHaveBeenCalledTimes(1);
+        expect(companyRetrieve).toHaveBeenLastCalledWith(req, {
+            id: 1,
+        });
+
+        // DataLoader api
+        mockConfig = {
+            createKey: mockCreateKey,
+        };
+
+        company = await wrapper(req, { id: 1 });
+        expect(companyRetrieve).toHaveBeenCalledTimes(2);
+        expect(company.id).toBe(1);
+
+    });
+
+});

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -1,0 +1,83 @@
+/* Use DataLoader library for in-memory request deduplication.
+ *
+ * DataLoader consolidates all Promises for the same loader and input key
+ * during a single node "clock-tick", removing the need to evaluation some
+ * duplication requests.
+ *
+ * DataLoader does not do anything magic that spans multiple clock-ticks.
+ * Our own batching and caching are necessary in many cases.
+ */
+import DataLoader from 'dataloader';
+import uuidv4 from 'uuid/v4';
+import { get } from 'lodash';
+import { bind, getContainer } from '@globality/nodule-config';
+import { concurrentPaginate } from '../../modules';
+
+
+/* Fetch (and lazy-create) loaders by name.
+ *
+ * Loaders are cached on the request for re-use. Loaders are not shared
+ * across requests because of potential to violate access control policies
+ * between concurrent users.
+ */
+function getLoader(req, loaderId, loadMany, allowBatch) {
+    const base = getContainer();
+    const { createKey } = getContainer();
+
+    let loader = get(base, `loaders.${loaderId}`);
+    if (!loader) {
+        loader = new DataLoader(
+            argsList => loadMany(req, argsList),
+            {
+                // key uses a json like representation of ordered keys
+                // straight json would not work if parameters came in different order
+                cacheKeyFn: args => createKey(args),
+                batch: allowBatch,
+            },
+        );
+        bind(`loaders.${loaderId}`, loader);
+    }
+    return loader;
+}
+
+
+/* Is a response object from a DataLoader function an errror (vs a BE result).
+ *
+ * An error object is an object with:
+ *   1. An error key (with Error as value)
+ *   2. An (optional) id key (such as id, userId, etc) and value
+ */
+function isError(object) {
+    return (object.error && Object.keys(object).length <= 2);
+}
+
+
+/* Wrapper that uses DataLoader for in-request de-duplication.
+ */
+export function dedupMany(loadMany, { loaderName, allowBatch = false }) {
+    const loaderId = loaderName || uuidv4();
+    // Fetch the loader in call time - (and in the req init)
+    return async (req, args) => getLoader(
+        req,
+        loaderId,
+        loadMany,
+        allowBatch,
+    ).load(args).then((res) => {
+        // special case - batch wrapper can an object with an error key to raise
+        if (isError(res)) {
+            throw res.error;
+        }
+        return res;
+    });
+}
+
+
+/* Wrapper that uses DataLoader for in-request de-duplication.
+ */
+export default function dedup(load, { loaderName }) {
+    const loadMany = async (req, argsList = []) => concurrentPaginate(
+        argsList.map(args => load(req, args)),
+    );
+
+    return dedupMany(loadMany, { loaderName });
+}

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,40 @@
+import { cloneDeepWith } from 'lodash';
+import { bind, getContainer } from '@globality/nodule-config';
+import getServiceWrappers from './wrapper';
+import createKeyFunc from './core/keys';
+
+export function cloneClients(obj) {
+    return cloneDeepWith(obj, node => (
+        typeof node === 'function' ?
+            async (req, args) => node(req, args) :
+            Object.keys(node).reduce(
+                (acc, key) => ({ ...acc, [key]: cloneClients(node[key]) }),
+                {},
+            )
+    ));
+}
+
+/* Wraps clients with the configured services (batching, dedup, etc.)
+ * We clone the clients to avoid modifying to the original clients
+ */
+function wrapClients(clients) {
+    const servicesWrappers = getServiceWrappers();
+    const services = cloneClients(clients);
+    Object.keys(servicesWrappers).forEach((requestName) => {
+        services[requestName] = servicesWrappers[requestName];
+    });
+    return services;
+}
+
+export default function bindServices() {
+    const { createKey } = getContainer();
+    if (!createKey) {
+        bind('createKey', () => createKeyFunc);
+    }
+    const { clientsName } = getContainer();
+    const clients = getContainer(clientsName || 'clients');
+    const services = wrapClients(clients);
+    Object.keys(services).forEach((clientName) => {
+        bind(`services.${clientName}`, () => services[clientName]);
+    });
+}

--- a/src/services/wrapper.js
+++ b/src/services/wrapper.js
@@ -1,0 +1,66 @@
+/* Wrap service calls by composing multiple wrapper functions.
+ *
+ * We support batching, caching, and (in-request) deduplication.
+ */
+import { flatten } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
+
+import batched from './batching/wrapper';
+import deduped from './dedup/wrapper';
+import named from './core/named';
+
+function buildWrappers() {
+    const wrappers = [];
+    const { serviceConfig } = getContainer();
+    if (serviceConfig) {
+        const { dedup, batch, additionalWrappers } = serviceConfig;
+        // NB: order matters here
+        if (dedup) {
+            wrappers.push([dedup, deduped]);
+        }
+
+        if (batch) {
+            wrappers.push([batch, batched]);
+        }
+
+        if (additionalWrappers) {
+            wrappers.push(...additionalWrappers);
+        }
+    }
+    return wrappers;
+}
+
+/* Wrap a service call if args are defined.
+ */
+export function wrapIf(service, wrapper, args) {
+    return args ? wrapper(service, args) : service;
+}
+
+
+/* Wrap a single service call.
+ */
+function wrap(wrappers, name) {
+    return wrappers.reduce(
+        (service, [config, wrapper]) => wrapIf(service, wrapper, config[name]),
+        named(name),
+    );
+}
+
+
+function getServiceWrappers() {
+    const wrappers = buildWrappers();
+
+    // calculate the full list of service names that are wrapped
+    const wrappedServiceNames = Array.from(new Set(
+        flatten(
+            wrappers.map(value => Object.keys(value[0])),
+        ),
+    ));
+
+    return Object.assign(
+        {},
+        ...wrappedServiceNames.map(name => ({ [name]: wrap(wrappers, name) })),
+    );
+}
+
+export default getServiceWrappers;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5002,7 +5006,7 @@ uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@^3.1.0:
+uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
* Wrap OpenAPI clients into services that applies logic across all clients
* Includes batching/deduplication logic that is activated by passing in a config for each (see README)
* Support for additional service layers (from configuration)