### PR TITLE
Fix binding to loaders

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.1
+current_version = 0.21.2
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.21.1",
+    "version": "0.21.2",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/services/batching/__tests__/wrapper.test.js
+++ b/src/services/batching/__tests__/wrapper.test.js
@@ -1,4 +1,4 @@
-import { get as mockGet } from 'lodash';
+import { get as mockGet, set as mockSet } from 'lodash';
 import mockCreateKey from '../../core/keys';
 import batched from '../wrapper';
 
@@ -12,7 +12,7 @@ const mockConfig = {
 };
 jest.mock('@globality/nodule-config', () => ({
     bind: (key, value) => {
-        mockConfig[key] = value;
+        mockSet(mockConfig, key, value());
         return mockConfig;
     },
     getContainer: () => (mockConfig),

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -1,12 +1,14 @@
+import { set as mockSet } from 'lodash';
 import dedup from '../wrapper';
 import mockCreateKey from '../../core/keys';
 
 let mockConfig = {
     createKey: mockCreateKey,
+    loaders: {},
 };
 jest.mock('@globality/nodule-config', () => ({
     bind: (key, value) => {
-        mockConfig[key] = value;
+        mockSet(mockConfig, key, value());
         return mockConfig;
     },
     getContainer: () => mockConfig,

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -21,10 +21,10 @@ import { concurrentPaginate } from '../../modules';
  * between concurrent users.
  */
 function getLoader(req, loaderId, loadMany, allowBatch) {
-    const base = getContainer();
+    const { loaders } = getContainer();
     const { createKey } = getContainer();
 
-    let loader = get(base, `loaders.${loaderId}`);
+    let loader = get(loaders, loaderId);
     if (!loader) {
         loader = new DataLoader(
             argsList => loadMany(req, argsList),
@@ -35,7 +35,7 @@ function getLoader(req, loaderId, loadMany, allowBatch) {
                 batch: allowBatch,
             },
         );
-        bind(`loaders.${loaderId}`, loader);
+        bind(`loaders.${loaderId}`, () => loader);
     }
     return loader;
 }


### PR DESCRIPTION
Why?

To enable batching/deduplication