### PR TITLE
Fix data loader issue

### DIFF
--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -2,7 +2,7 @@ import { set as mockSet } from 'lodash';
 import dedup from '../wrapper';
 import mockCreateKey from '../../core/keys';
 
-let mockConfig = {
+const mockConfig = {
     createKey: mockCreateKey,
 };
 jest.mock('@globality/nodule-config', () => ({

--- a/src/services/dedup/__tests__/wrapper.test.js
+++ b/src/services/dedup/__tests__/wrapper.test.js
@@ -4,7 +4,6 @@ import mockCreateKey from '../../core/keys';
 
 let mockConfig = {
     createKey: mockCreateKey,
-    loaders: {},
 };
 jest.mock('@globality/nodule-config', () => ({
     bind: (key, value) => {
@@ -60,9 +59,7 @@ describe('dataLoader wrapper', () => {
         });
 
         // DataLoader api
-        mockConfig = {
-            createKey: mockCreateKey,
-        };
+        req.loaders.companyLoader.clearAll();
 
         company = await wrapper(req, { id: 1 });
         expect(companyRetrieve).toHaveBeenCalledTimes(2);

--- a/src/services/dedup/wrapper.js
+++ b/src/services/dedup/wrapper.js
@@ -9,8 +9,8 @@
  */
 import DataLoader from 'dataloader';
 import uuidv4 from 'uuid/v4';
-import { get } from 'lodash';
-import { bind, getContainer } from '@globality/nodule-config';
+import { get, set } from 'lodash';
+import { getContainer } from '@globality/nodule-config';
 import { concurrentPaginate } from '@globality/nodule-openapi';
 
 
@@ -21,10 +21,9 @@ import { concurrentPaginate } from '@globality/nodule-openapi';
  * between concurrent users.
  */
 function getLoader(req, loaderId, loadMany, allowBatch) {
-    const { loaders } = getContainer();
     const { createKey } = getContainer();
+    let loader = get(req, `loaders.${loaderId}`);
 
-    let loader = get(loaders, loaderId);
     if (!loader) {
         loader = new DataLoader(
             argsList => loadMany(req, argsList),
@@ -35,7 +34,7 @@ function getLoader(req, loaderId, loadMany, allowBatch) {
                 batch: allowBatch,
             },
         );
-        bind(`loaders.${loaderId}`, () => loader);
+        set(req, `loaders.${loaderId}`, loader);
     }
     return loader;
 }


### PR DESCRIPTION
Why?

Dedup and batch requests should only exist for the life time of the request