### PR TITLE
exposing the named function to imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,4 +19,4 @@ export {
     signPrivate,
 } from './testing';
 export { wrapResolvers } from './wrapper';
-export { default as bindServices } from './services';
+export { default as bindServices, named } from './services';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -3,6 +3,8 @@ import { bind, getContainer } from '@globality/nodule-config';
 import getServiceWrappers from './wrapper';
 import createKeyFunc from './core/keys';
 
+export { default as named } from './core/named';
+
 export function cloneClients(obj) {
     return cloneDeepWith(obj, node => (
         typeof node === 'function' ?


### PR DESCRIPTION
Why?
when using the batched wrapper, we need to use the named function for building
the batching configuration