### PR TITLE
Expose dedup function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,3 +20,4 @@ export {
 } from './testing';
 export { wrapResolvers } from './wrapper';
 export { default as bindServices, named } from './services';
+export { default as dedup } from './services/dedup/wrapper';


### PR DESCRIPTION
Why?

To be used by other services such as caching