### PR TITLE
Release/0.28.0 (#83)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.0
+current_version = 0.28.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.27.0",
+    "version": "0.28.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",


### PR DESCRIPTION
* bump logging version

* GLOB-28139 - allowing multiple requireArgs sets (#82)

Why?
Some service calls are called with different args in different context. This
change allows for multiple versions of the requireArgs parameter, without
breaking current usage of the API.

What I've done:
1. instead of using a single requireArgs list, we check against an array
of requiredArgs, and if one of the versions fits the passed arguments, we cache
2. added tests for multiple versions, while making sure current tests still pass

* bump to 0.28.0