### PR TITLE
Add formatError function to graphqlExpress options

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.28.0
+current_version = 0.29.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@globality/nodule-config": "~2.4.1",
         "@globality/nodule-express": "~0.1.3",
         "@globality/nodule-logging": "~1.4.0",
-        "@globality/nodule-openapi": "~0.9.3",
+        "@globality/nodule-openapi": "~0.14.0",
         "babel-cli": "^6.26.0",
         "babel-eslint": "^8.2.2",
         "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -115,9 +115,9 @@ describe('routes', () => {
     });
 
     it('handles custom errors with x-request-id header', async () => {
-      const app = createApp();
+        const app = createApp();
 
-      const query = `
+        const query = `
         query example {
           user(id: "999") {
             items {
@@ -129,23 +129,23 @@ describe('routes', () => {
             }
           }
         }`;
-      const response = await request(app).post(
-          '/graphql',
-      ).send({
-          query,
-      });
+        const response = await request(app).post(
+            '/graphql',
+        ).send({
+            query,
+        });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body.data).toEqual({
-          user: null,
-      });
-      expect(response.body.errors).toHaveLength(1);
-      expect(response.body.errors[0].extensions.code).toEqual(503);
-      expect(response.body.errors[0].extensions.traceId).toEqual('1234');
-      expect(response.body.errors[0].locations).toBeDefined();
-      expect(response.body.errors[0].message).toEqual('Custom error');
-      expect(response.body.errors[0].path).toEqual([
-          'user',
-      ]);
+        expect(response.statusCode).toBe(200);
+        expect(response.body.data).toEqual({
+            user: null,
+        });
+        expect(response.body.errors).toHaveLength(1);
+        expect(response.body.errors[0].extensions.code).toEqual(503);
+        expect(response.body.errors[0].extensions.traceId).toEqual('1234');
+        expect(response.body.errors[0].locations).toBeDefined();
+        expect(response.body.errors[0].message).toEqual('Custom error');
+        expect(response.body.errors[0].path).toEqual([
+            'user',
+        ]);
     });
 });

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -72,7 +72,9 @@ describe('routes', () => {
             user: null,
         });
         expect(response.body.errors).toHaveLength(1);
-        expect(response.body.errors[0].extensions.code).toEqual('HTTP-404');
+        expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
+            code: 'HTTP-404',
+        }));
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('No such user');
         expect(response.body.errors[0].path).toEqual([
@@ -106,7 +108,9 @@ describe('routes', () => {
             user: null,
         });
         expect(response.body.errors).toHaveLength(1);
-        expect(response.body.errors[0].extensions.code).toEqual('HTTP-403');
+        expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
+            code: 'HTTP-404',
+        }));
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('Not Authorized');
         expect(response.body.errors[0].path).toEqual([
@@ -114,7 +118,7 @@ describe('routes', () => {
         ]);
     });
 
-    it('handles custom errors with x-request-id header', async () => {
+    it('handles custom errors with x-request-id and x-trace-id headers', async () => {
         const app = createApp();
 
         const query = `
@@ -140,8 +144,11 @@ describe('routes', () => {
             user: null,
         });
         expect(response.body.errors).toHaveLength(1);
-        expect(response.body.errors[0].extensions.code).toEqual(503);
-        expect(response.body.errors[0].extensions.traceId).toEqual('1234');
+        expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
+            code: 503,
+            requestId: '1234',
+            traceId: '5432',
+        }));
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('Custom error');
         expect(response.body.errors[0].path).toEqual([

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -72,7 +72,7 @@ describe('routes', () => {
             user: null,
         });
         expect(response.body.errors).toHaveLength(1);
-        expect(response.body.errors[0].code).toEqual('HTTP-404');
+        expect(response.body.errors[0].extensions.code).toEqual('HTTP-404');
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('No such user');
         expect(response.body.errors[0].path).toEqual([
@@ -106,11 +106,46 @@ describe('routes', () => {
             user: null,
         });
         expect(response.body.errors).toHaveLength(1);
-        expect(response.body.errors[0].code).toEqual('HTTP-403');
+        expect(response.body.errors[0].extensions.code).toEqual('HTTP-403');
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('Not Authorized');
         expect(response.body.errors[0].path).toEqual([
             'user',
         ]);
+    });
+
+    it('handles custom errors with x-request-id header', async () => {
+      const app = createApp();
+
+      const query = `
+        query example {
+          user(id: "999") {
+            items {
+              companyId
+              companyName
+              firstName
+              id
+              lastName
+            }
+          }
+        }`;
+      const response = await request(app).post(
+          '/graphql',
+      ).send({
+          query,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.data).toEqual({
+          user: null,
+      });
+      expect(response.body.errors).toHaveLength(1);
+      expect(response.body.errors[0].extensions.code).toEqual(503);
+      expect(response.body.errors[0].extensions.traceId).toEqual('1234');
+      expect(response.body.errors[0].locations).toBeDefined();
+      expect(response.body.errors[0].message).toEqual('Custom error');
+      expect(response.body.errors[0].path).toEqual([
+          'user',
+      ]);
     });
 });

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -109,7 +109,7 @@ describe('routes', () => {
         });
         expect(response.body.errors).toHaveLength(1);
         expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
-            code: 'HTTP-404',
+            code: 'HTTP-403',
         }));
         expect(response.body.errors[0].locations).toBeDefined();
         expect(response.body.errors[0].message).toEqual('Not Authorized');

--- a/src/__tests__/services.js
+++ b/src/__tests__/services.js
@@ -21,6 +21,7 @@ async function retrieveUser(userId) {
         error.code = 503;
         error.headers = {
             'x-request-id': '1234',
+            'x-trace-id': '5432',
         };
         throw error;
     }

--- a/src/__tests__/services.js
+++ b/src/__tests__/services.js
@@ -16,6 +16,15 @@ async function retrieveCompany(companyId) {
 
 
 async function retrieveUser(userId) {
+    if (userId && userId === '999') {
+        const error = new Error('Custom error');
+        error.code = 503;
+        error.headers = {
+            'x-request-id': '1234',
+        };
+        throw error;
+    }
+
     if (userId && userId !== '30') {
         throw new NotFound('No such user');
     }

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -23,6 +23,53 @@ function injectExtensions(req) {
     };
 }
 
+/**
+ * Format the given error before it is serialized and sent to the client
+ */
+function formatError(error) {
+    const extensions = error.extensions || {};
+    const originalError = error.originalError || {};
+    const code = extensions.code || originalError.code;
+    const headers = originalError.headers || {};
+    const traceId = (
+        extensions.traceId ||
+        originalError.traceId ||
+        headers['x-trace-id'] ||
+        headers['x-request-id']
+    );
+
+    // Include the HTTP status code and trace ID if they exist. These can come from the underlying
+    // HTTP library such as axios. Including this information in the error for the benefit of the
+    // client that made the request.
+    //
+    // The `extensions` field conforms with the GraphQL format error specification, section 7.1.2
+    // @see https://graphql.github.io/graphql-spec/June2018/#sec-Errors
+
+    // N.B. Need to create a new error in order to avoid any potential read-only issue trying to
+    // modify the given error
+    const newError = new Error();
+
+    // According to section 7.1.2 of the GraphQL specification, fields `message`, and `path` are
+    // required. The `locations` field may be included.
+    newError.message = error.message;
+    newError.path = error.path;
+
+    if (error.locations) {
+        newError.locations = error.locations;
+    }
+
+    const exts = newError.extensions = {};
+
+    if (code) {
+        exts.code = code;
+    }
+
+    if (traceId) {
+        exts.traceId = traceId;
+    }
+
+    return newError;
+}
 
 function makeGraphqlOptions(config, graphql) {
     const { schema } = graphql;
@@ -40,6 +87,7 @@ function makeGraphqlOptions(config, graphql) {
             rootValue: null,
             schema,
             tracing: config.routes.graphql.cacheControl || req.headers['x-request-trace'],
+            formatError,
         };
     };
 }

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -34,13 +34,17 @@ function formatError(error) {
     const traceId = (
         extensions.traceId ||
         originalError.traceId ||
-        headers['x-trace-id'] ||
+        headers['x-trace-id']
+    );
+    const requestId = (
+        extensions.requestId ||
+        originalError.requestId ||
         headers['x-request-id']
     );
 
-    // Include the HTTP status code and trace ID if they exist. These can come from the underlying
-    // HTTP library such as axios. Including this information in the error for the benefit of the
-    // client that made the request.
+    // Include the HTTP status code, trace ID and request ID if they exist. These can come from
+    // the underlying HTTP library such as axios. Including this information in the error for the
+    // benefit of the client that made the request.
     //
     // The `extensions` field conforms with the GraphQL format error specification, section 7.1.2
     // @see https://graphql.github.io/graphql-spec/June2018/#sec-Errors
@@ -69,6 +73,10 @@ function formatError(error) {
         newExts.traceId = traceId;
     }
 
+    if (requestId) {
+        newExts.requestId = requestId;
+    }
+
     return newError;
 }
 
@@ -76,7 +84,6 @@ function makeGraphqlOptions(config, graphql) {
     const { schema } = graphql;
 
     // XXX need to add:
-    //  - formatError
     //  - formatResponse/injectExtensions
 
     return function configure(req) {

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -58,14 +58,15 @@ function formatError(error) {
         newError.locations = error.locations;
     }
 
-    const exts = newError.extensions = {};
+    const newExts = {};
+    newError.extensions = newExts;
 
     if (code) {
-        exts.code = code;
+        newExts.code = code;
     }
 
     if (traceId) {
-        exts.traceId = traceId;
+        newExts.traceId = traceId;
     }
 
     return newError;

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,12 +116,13 @@
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 
-"@globality/nodule-openapi@~0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-openapi/-/nodule-openapi-0.9.3.tgz#b64d322e9ffa27129c668145bf809c788ad5e348"
+"@globality/nodule-openapi@~0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-openapi/-/nodule-openapi-0.14.0.tgz#71a003d04bfdbe830727ea87a6befb4848a3949e"
+  integrity sha512-U1/M4/i7aZm8tgfFmnH9OulSaATrdT635oiQ5O2w2h1h7TQFksVzRlcq/4fIKlF7TwhDKnOt1hnSBiL9lX8NMA==
   dependencies:
     "@globality/nodule-config" "^2.3.0"
-    axios "^0.18.0"
+    axios "^0.18.1"
     http-status-codes "^1.3.0"
     lodash "^4.17.5"
     throat "^4.1.0"
@@ -402,6 +403,14 @@ axios@^0.18.0:
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
+
+axios@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 babel-cli@^6.26.0:
   version "6.26.0"
@@ -1461,7 +1470,7 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@=3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2071,6 +2080,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
@@ -2543,6 +2559,11 @@ is-binary-path@^1.0.0:
 is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Added a `formatError` for graphqlExpress

The format error function adds meaningful extensions to each error that are useful for clients to better diagnose and handle errors. Formatted error adhere to section 7.1.2 of the GraphQL specification https://graphql.github.io/graphql-spec/June2018/#sec-Errors