### PR TITLE
GLOB-38213 fix broken caching logging

### DIFF
--- a/src/services/caching/__tests__/logging.test.js
+++ b/src/services/caching/__tests__/logging.test.js
@@ -1,0 +1,42 @@
+import logCacheUsage from '../logging';
+
+jest.mock('@globality/nodule-config', () => ({
+    bind: () => null,
+    getContainer: () => ({
+        config: {
+            logger: {
+                cache: {
+                    enabled: true,
+                },
+            },
+        },
+        logger: {
+            info: jest.fn(),
+        },
+    }),
+    setDefaults: () => null,
+}));
+
+describe('logCacheUsage', () => {
+    const testArguments = [
+        {
+            cacheTTL: 'spec.cacheTTL',
+            resourceName: 'spec.resourceName',
+            requireArgs: { },
+        }, // spec
+        'req',
+        'key',
+        { value: 'result.value' }, // result
+        [0, 0], // executeStartTime
+    ];
+
+    it('exists', () => {
+        expect(logCacheUsage).toBeDefined();
+        expect(typeof logCacheUsage).toBe('function');
+    });
+
+    it('runs without error', () => {
+        logCacheUsage(...testArguments);
+        // test passes if no errors
+    });
+});

--- a/src/services/caching/logging.js
+++ b/src/services/caching/logging.js
@@ -1,7 +1,8 @@
 import { get } from 'lodash';
 import { getContainer } from '@globality/nodule-config';
 import { extractLoggingProperties } from '@globality/nodule-logging';
-import { calculateExecuteTime } from '@globality/nodule-express';
+
+import { calculateExecuteTime } from '../../logging';
 
 export default function logCacheUsage(spec, req, key, result, executeStartTime) {
     const { config, logger } = getContainer();


### PR DESCRIPTION
Part of [GLOB-38213]

Logging for GW caches was broken because of the following line:

```javascript
import { calculateExecuteTime } from '@globality/nodule-express';
```

This function isn't exported from `nodule-express`, but usefully it's duplicated within this library. This commit switches the import location so logging can work correctly.

[GLOB-38213]: https://globality.atlassian.net/browse/GLOB-38213