### PR TITLE
Add apollo graph manager integration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.0
+current_version = 0.33.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.32.0",
+    "version": "0.33.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -95,8 +95,8 @@ function redactGQLVariables (vars) {
 
 function makeGraphqlOptions(config, graphql) {
     const { schema } = graphql;
-    var apolloEngineConfig = config.routes.graphql.apolloEngine;
-    var engine = {
+    const apolloEngineConfig = config.routes.graphql.apolloEngine;
+    const engine = {
         apiKey: apolloEngineConfig.apiKey,
         schemaTag: apolloEngineConfig.schemaTag,
         sendVariableValues: {
@@ -137,9 +137,9 @@ setDefaults('routes.graphql.apolloEngine', {
      * for details
      */
     apiKey: null,
-    
+
     /** Tag for GQL schema used by Apollo Graph Manager.
-     * 
+     *
      * Refer to https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions
      * for details
      */


### PR DESCRIPTION
Ticket: https://globality.atlassian.net/browse/GLOB-39528

Updated the graphql route to include optional Apollo Graph Manager configuration to the Apollo server instance.

configuration keys:

- `routes.graphql.apolloEngine.enabled`
- `routes.graphql.apolloEngine.apiKey`
- `routes.graphql.apolloEngine.schemaTag`

Apollo Graph manager ("engine") is enabled if the `.enabled` config is set to true. If the engine is enabled then an API ke (`.apiKey`) and schema tag (`.schemaTag`) are expected.

## Other Details

- Metrics sent to the Apollo Graph manager will only HTTP headers `user-agent`, `x-request-id` and `x-request-user`. 
- Variables used for a GQL operation will be filtered before being sent to Apollo Graph Manager. Only fields that end with `Id` or `Type` or are `id` will not be redacted, otherwise the value for the field will be set to `[REDACTED]`