### PR TITLE
major version bump 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.0
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v1.0.0
 
-- Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking (upgraded to graphal@14.x)
+- Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking change (upgraded to graphal@14.x)
 
 ### v0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.0.0
+
+- Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking (upgraded to graphal@14.x)
+
 ### v0.32.0
 
 [See complete versioning details.](https://github.com/globality-corp/nodule-graphql/commit/e8d251f39d0263e495cae8c99e86179808584019)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "0.32.0",
+    "version": "1.0.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",


### PR DESCRIPTION
Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking change (upgraded to graphal@14.x)

See commit https://github.com/globality-corp/nodule-graphql/pull/95