### PR TITLE
add graphql route factory binding

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.1.0
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v1.0.1
+
+- Added a `factories.routes.grapql` binding. Gives more direct control over how the graphql route is created. This is optional use. Standard `routes.graphql` binding
+continues to work as normal. 
+
 ### v1.0.0
 
 - Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking change (upgraded to graphal@14.x)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v1.0.1
+### v1.1.0
 
 - Added a `factories.routes.grapql` binding. Gives more direct control over how the graphql route is created. This is optional use. Standard `routes.graphql` binding
 continues to work as normal. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -182,15 +182,16 @@ describe('routes', () => {
                     lastName
                   }
                 }
-              }`;
-            
-              const response = await request(app).post(
-                  '/graphql',
-              ).send({
-                  query,
-              });
+              }
+            `;
 
-              expect(response.statusCode).toBe(200);
+            const response = await request(app).post(
+                '/graphql',
+            ).send({
+                query,
+            });
+
+            expect(response.statusCode).toBe(200);
         });
 
     });

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -1,9 +1,9 @@
 import request from 'supertest';
+import express from 'express';
 
-import { Nodule } from '@globality/nodule-config';
+import { Nodule, getContainer } from '@globality/nodule-config';
 
 import createApp from './app';
-
 
 describe('routes', () => {
     beforeEach(async () => {
@@ -154,5 +154,44 @@ describe('routes', () => {
         expect(response.body.errors[0].path).toEqual([
             'user',
         ]);
+    });
+
+    describe('graphql route factory', () => {
+
+        it('will create a working graphql route', async () => {
+            const factories = getContainer('factories');
+            const createGraphQlRoute = factories.routes.graphql;
+
+            expect(createGraphQlRoute).toEqual(expect.any(Function));
+
+            const graphql = createGraphQlRoute();
+
+            expect(graphql).toEqual(expect.any(Function));
+
+            const app = express();
+            app.post('/graphql', graphql);
+
+            const query = `
+              query example {
+                user(id: "999") {
+                  items {
+                    companyId
+                    companyName
+                    firstName
+                    id
+                    lastName
+                  }
+                }
+              }`;
+            
+              const response = await request(app).post(
+                  '/graphql',
+              ).send({
+                  query,
+              });
+
+              expect(response.statusCode).toBe(200);
+        });
+
     });
 });

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -1,7 +1,7 @@
 import { get, merge, pickBy } from 'lodash';
 import { ApolloServer } from 'apollo-server-express';
 
-import { bind, getContainer, setDefaults } from '@globality/nodule-config';
+import { bind, getContainer } from '@globality/nodule-config';
 
 
 /* Inject custom extensions in the graphql response.
@@ -81,7 +81,7 @@ function formatError(error) {
 
 function makeGraphqlOptions(config, graphql) {
     const { schema } = graphql;
-    const { apolloEngine = {} } = config;
+    const { apolloEngine } = config;
 
     return {
         context: ({ req }) => req,
@@ -90,7 +90,7 @@ function makeGraphqlOptions(config, graphql) {
         playground: false,
         rootValue: null,
         schema,
-        engine: apolloEngine ? apolloEngine : false,
+        engine: apolloEngine || false,
     };
 }
 
@@ -106,29 +106,25 @@ function createGraphQLRoute (config = {}) {
 }
 
 
-bind('routes.graphql', () => {
-    return createGraphQLRoute();
-});
+bind('routes.graphql', () => createGraphQLRoute());
 
 /**
  * GraphQL route factory
- * 
+ *
  * Use this when you want to have direct control over the creation
  * of the graphql route.
- * 
+ *
  * Factory takes an optional config object with the following interface:
- * 
+ *
  *   interface GraphQLRouteOptions {
  *       apolloEngine: {
  *           ...
  *       }
  *   }
- * 
+ *
  * where `apolloEngine` is the configuration passed to the underlying
  * apollo server.
- * 
+ *
  * see https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions
  */
-bind('factories.routes.graphql', () => {
-    return createGraphQLRoute;
-});
+bind('factories.routes.graphql', () => createGraphQLRoute);


### PR DESCRIPTION
Added a `factories.routes.graphql` binding used to directly control the creation of the graphql route. This does not replace the `routes.graphql` binding.

Factory takes in a configuration used to create the graphql route. Namely, the configuration currently takes an optional Apollo engine configurations that will be supplied to the underlying Apollo Server (see https://www.apollographql.com/docs/apollo-server/api/apollo-server/#enginereportingoptions) 