### PR TITLE
Add GraphQL route Apollo engine config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v1.1.0
+
+- Added `routes.graphql.apolloEngine` config. Used to configure Apollo engine used by the Apollo Server instances that drives the graphql route.
+- `tracing` and `cacheControl` graphql route config options are now deprecatd. They are only intended for the now deprecated Apollo engine proxy. Config options will eventually
+be removed.
+
 ### v1.0.0
 
 - Major revision from v0.32.0 to v1.0.0. Addresses v0.32.0's semantic breaking change (upgraded to graphal@14.x)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -117,7 +117,7 @@ describe('routes', () => {
         ]);
     });
 
-    it.only('handles custom errors with x-request-id and x-trace-id headers', async () => {
+    it('handles custom errors with x-request-id and x-trace-id headers', async () => {
         const app = createApp();
 
         const query = `

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -4,7 +4,6 @@ import { Nodule } from '@globality/nodule-config';
 
 import createApp from './app';
 
-
 describe('routes', () => {
     beforeEach(async () => {
         await Nodule.testing().load();
@@ -118,7 +117,7 @@ describe('routes', () => {
         ]);
     });
 
-    it('handles custom errors with x-request-id and x-trace-id headers', async () => {
+    it.only('handles custom errors with x-request-id and x-trace-id headers', async () => {
         const app = createApp();
 
         const query = `
@@ -155,4 +154,5 @@ describe('routes', () => {
             'user',
         ]);
     });
+
 });

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -1,0 +1,70 @@
+import {
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLSchema,
+} from 'graphql';
+
+import { bind, setDefaults, getContainer, Nodule } from '@globality/nodule-config';
+
+jest.mock('apollo-server-express');
+
+import * as apolloServerExpress from 'apollo-server-express'; // eslint-disable-line import/first
+import '../graphql'; // eslint-disable-line import/first
+import '../../terminal'; // eslint-disable-line import/first
+
+const QueryType = new GraphQLObjectType({
+    name: 'QueryType',
+    description: 'Top-level queries',
+    fields: {
+        hello: {
+            type: GraphQLString,
+            resolve: () => 'world',
+        },
+    },
+});
+
+
+const schema = new GraphQLSchema({
+    query: QueryType,
+});
+
+
+bind('graphql.schema', () => schema);
+
+describe('routes.graphql', () => {
+
+    it('will supply apollo engine configs to apollo server instance', async () => {
+        const mockApolloServer = jest.fn();
+        apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
+
+        setDefaults('routes.graphql.apolloEngine', {
+            enabled: true,
+            apiKey: 'mock-api-key',
+            schemaTag: 'mock-schema-tag',
+            sendVariableValues: {
+                transform: value => value,
+            },
+            sendHeaders: {
+                onlyNames: ['x-mock-header'],
+            },
+        });
+
+        await Nodule.testing().load();
+
+        getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
+
+        expect(mockApolloServer.mock.calls).toHaveLength(1);
+        expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
+        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('engine', expect.objectContaining({
+            apiKey: 'mock-api-key',
+            schemaTag: 'mock-schema-tag',
+            sendVariableValues: {
+                transform: expect.any(Function),
+            },
+            sendHeaders: {
+                onlyNames: ['x-mock-header'],
+            },
+        }));
+    });
+
+});


### PR DESCRIPTION
Updated `routes.graphql` to accept an apollo engine config (`routes.graphql.apolloEngine`). Can use the config to enable the Apollo engine in addition to applying specific Apollo Engine options such as API key, schema tag and what GQL variables and HTTP headers are sent to Apollo Graph Manager when tracing.

Deprecated graphql route `tracing` and `cacheControl` config options.