### PR TITLE
Add config to hide errors in message responses

### DIFF
--- a/src/__tests__/routes.hideErrors.test.js
+++ b/src/__tests__/routes.hideErrors.test.js
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+import { Nodule } from '@globality/nodule-config';
+
+import createApp from './app';
+
+describe('hide errors', () => {
+
+    beforeEach(async () => {
+        await Nodule.testing().fromObject({
+            routes: {
+                graphql: {
+                    hideErrors: true,
+                },
+            },
+        }).load();
+    });
+
+    it('hides errors', async () => {
+        const app = createApp();
+        const query = `
+          query example {
+            user(id: "99") {
+              items {
+                companyId
+                companyName
+                firstName
+                id
+                lastName
+              }
+            }
+          }`;
+        const response = await request(app).post(
+            '/graphql',
+        ).send({
+            query,
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.data).toEqual({
+            user: null,
+        });
+        expect(response.body.errors).toHaveLength(1);
+        expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
+            code: 'HTTP-404',
+        }));
+        expect(response.body.errors[0].locations).toBeDefined();
+        expect(response.body.errors[0].message).toEqual('');
+        expect(response.body.errors[0].path).toEqual([
+            'user',
+        ]);
+    });
+});

--- a/src/__tests__/routes.hideErrors.test.js
+++ b/src/__tests__/routes.hideErrors.test.js
@@ -45,7 +45,7 @@ describe('hide errors', () => {
             code: 'HTTP-404',
         }));
         expect(response.body.errors[0].locations).toBeDefined();
-        expect(response.body.errors[0].message).toEqual('');
+        expect(response.body.errors[0].message).toEqual('Gateway Error');
         expect(response.body.errors[0].path).toEqual([
             'user',
         ]);

--- a/src/__tests__/routes.test.js
+++ b/src/__tests__/routes.test.js
@@ -154,5 +154,4 @@ describe('routes', () => {
             'user',
         ]);
     });
-
 });

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -25,6 +25,10 @@ function injectExtensions(response, req) {
  * Format the given error before it is serialized and sent to the client
  */
 function formatError(error) {
+    const { config } = getContainer();
+    const graphqlConfig = config.routes.graphql;
+    const { hideErrors } = graphqlConfig;
+
     const extensions = error.extensions || {};
     const originalError = error.originalError || {};
     const code = extensions.code || originalError.code;
@@ -53,7 +57,10 @@ function formatError(error) {
 
     // According to section 7.1.2 of the GraphQL specification, fields `message`, and `path` are
     // required. The `locations` field may be included.
-    newError.message = error.message;
+    if (!hideErrors) {
+        newError.message = error.message;
+    }
+
     newError.path = error.path;
 
     if (error.locations) {
@@ -84,11 +91,11 @@ function createApolloServerOptions() {
     const graphqlConfig = config.routes.graphql;
 
     if (graphqlConfig.tracing) {
-        global.console.warn('DEPRACATED: config.routes.graphql.tracing. No longer used.');
+        global.console.warn('DEPRECATED: config.routes.graphql.tracing. No longer used.');
     }
 
     if (graphqlConfig.cacheControl) {
-        global.console.warn('DEPRACATED: config.routes.graphql.tracing. No longer used');
+        global.console.warn('DEPRECATED: config.routes.graphql.tracing. No longer used');
     }
 
     const { apolloEngine } = config.routes.graphql;
@@ -115,7 +122,7 @@ setDefaults('routes.graphql', {
      * Apollo caching is resource-based, not service-based. Caching should occur as close
      * as possible to the source of truth (e.g. at service calls).
      *
-     * @depracated
+     * @deprecated
      */
     cacheControl: false,
     /* Disable tracing by default.
@@ -123,9 +130,14 @@ setDefaults('routes.graphql', {
      * Tracing is verbose and increases volume. Tracing should be enabled if apollo engine
      * is enabled (which shared tracing over the local network).
      *
-     * @depracated
+     * @deprecated
      */
     tracing: false,
+
+    /**
+     * Suppress sending back full error messages back with responses
+     */
+    hideErrors: false,
 });
 
 


### PR DESCRIPTION
This adds the ability to prevent error messages from bubbling up to
clients, given that said messages may contain otherwise sensitive data.

It defaults to false to preserve current behavior; it will need to be
overridden to take effect.