### PR TITLE
Hotfix 1.3.1: Whitelist specific errors to always pass through

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/routes.hideErrors.test.js
+++ b/src/__tests__/routes.hideErrors.test.js
@@ -50,4 +50,39 @@ describe('hide errors', () => {
             'user',
         ]);
     });
+
+    it('doesnt hide persisted query errors', async () => {
+        const app = createApp();
+        const query = `
+          query example {
+            user(id: "888") {
+              items {
+                companyId
+                companyName
+                firstName
+                id
+                lastName
+              }
+            }
+          }`;
+        const response = await request(app).post(
+            '/graphql',
+        ).send({
+            query,
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.data).toEqual({
+            user: null,
+        });
+        expect(response.body.errors).toHaveLength(1);
+        expect(response.body.errors[0].extensions).toEqual(expect.objectContaining({
+            code: 'HTTP-404',
+        }));
+        expect(response.body.errors[0].locations).toBeDefined();
+        expect(response.body.errors[0].message).toEqual('PersistedQueryNotFound');
+        expect(response.body.errors[0].path).toEqual([
+            'user',
+        ]);
+    });
 });

--- a/src/__tests__/services.js
+++ b/src/__tests__/services.js
@@ -26,6 +26,10 @@ async function retrieveUser(userId) {
         throw error;
     }
 
+    if (userId && userId === '888') {
+        throw new NotFound('PersistedQueryNotFound');
+    }
+
     if (userId && userId !== '30') {
         throw new NotFound('No such user');
     }


### PR DESCRIPTION
Some external libraries rely on specific error message parsing in order to
work. Specifically, the apollo-link-persisted-queries looks for two exact
strings in order to function correctly.