### PR TITLE
GLOB-46007: Fix express-jwt vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "dataloader": "^1.4.0",
         "enum": "^2.4.0",
         "express": "^4.16.3",
-        "express-jwt": "^5.3.1",
+        "express-jwt": "^6.0.0",
         "graphql-playground-middleware-express": "^1.7.12",
         "helmet": "^3.12.0",
         "http-status-codes": "^1.3.0",
@@ -35,14 +35,14 @@
     },
     "peerDependencies": {
         "@globality/nodule-config": ">= 2.13.2 < 3",
-        "@globality/nodule-express": ">= 0.1.12 < 1",
+        "@globality/nodule-express": ">= 0.1.14 < 1",
         "@globality/nodule-logging": ">= 1.5.2 < 2",
         "@globality/nodule-openapi": ">= 0.17.2 < 1",
         "graphql": ">= 14.5.8 < 15"
     },
     "devDependencies": {
         "@globality/nodule-config": "~2.13.2",
-        "@globality/nodule-express": "^0.1.12",
+        "@globality/nodule-express": "^0.1.14",
         "@globality/nodule-logging": "~1.5.2",
         "@globality/nodule-openapi": "^0.17.2",
         "@babel/cli": "^7.7.0",

--- a/src/middleware/jwt/middleware.js
+++ b/src/middleware/jwt/middleware.js
@@ -42,6 +42,7 @@ export default function middleware(req, res, next) {
         secret: negotiateKey,
         audience: matchingAudience,
         requestProperty: 'locals.jwt',
+        algorithms: ['HS256', 'RS256'],
     });
 
     return validator(req, res, (error) => {

--- a/src/middleware/jwt/middleware.js
+++ b/src/middleware/jwt/middleware.js
@@ -1,4 +1,5 @@
 import jwt from 'express-jwt';
+import { get } from 'lodash';
 
 import { getConfig, getMetadata, getContainer } from '@globality/nodule-config';
 
@@ -38,11 +39,17 @@ export default function middleware(req, res, next) {
 
     const matchingAudience = chooseAudience(audience);
 
+    const algorithms = get(config, 'algorithms', 'HS256,RS256').split(',').filter(
+        algorithm => !!algorithm,
+    ).map(
+        algorithm => algorithm.trim(),
+    );
+
     const validator = jwt({
         secret: negotiateKey,
         audience: matchingAudience,
         requestProperty: 'locals.jwt',
-        algorithms: ['HS256', 'RS256'],
+        algorithms,
     });
 
     return validator(req, res, (error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,22 +739,20 @@
     bottlejs "^1.7.0"
     lodash "^4.17.15"
 
-"@globality/nodule-express@^0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-express/-/nodule-express-0.1.12.tgz#73960ebeb2cc66f040272bf521448664b255c626"
-  integrity sha512-2jpjdAdcoZ9vI0htCvucDeEf7C8MRu3z8++qOrGQXBBuVRkkvoIqTM+pZKpQkKrQ3+6ebyv7ewfTQ+miXCgKuQ==
+"@globality/nodule-express@^0.1.14":
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-express/-/nodule-express-0.1.14.tgz#0ba1c2bf663b1d352601b23cbc39a2c334490aee"
+  integrity sha512-UE41yF9LOvSdivCs0Zlg4PzUamHnirTcpDoflqo6CQUJUwb+32iEnhXIi5svXts+wFiTN9yzwpl1bZzXulvs7w==
   dependencies:
     basic-auth "^1.1.0"
     connect-requestid "^1.1.0"
     cors "^2.8.4"
     dataloader "^1.4.0"
     express "^4.16.3"
-    express-jwt "^5.3.1"
     helmet "^3.12.0"
     http-status-codes "^1.3.0"
     jsonwebtoken "^8.2.0"
     lodash "^4.17.5"
-    yarn "^1.5.1"
 
 "@globality/nodule-logging@~1.5.2":
   version "1.5.2"
@@ -2760,10 +2758,10 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express-jwt@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-5.3.1.tgz#66f05c7dddb5409c037346a98b88965bb10ea4ae"
-  integrity sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==
+express-jwt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-6.0.0.tgz#20886c730983ffb1c706a4383235df86eff349b8"
+  integrity sha512-C26y9myRjx7CyhZ+BAT3p+gQyRCoDZ7qo8plCvLDaRT6je6ALIAQknT6XLVQGFKwIy/Ux7lvM2MNap5dt0T7gA==
   dependencies:
     async "^1.5.0"
     express-unless "^0.3.0"
@@ -6508,11 +6506,6 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
-
-yarn@^1.5.1:
-  version "1.21.1"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
-  integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
 
 zen-observable-ts@^0.8.20:
   version "0.8.20"


### PR DESCRIPTION
**Why?**

This PR is a part of fixing `express-jwt` vulnerability.

**What?**

- updated `express-jwt` to the 6.0.0
- updated `nodule-express` to the latest version
- provided `algorithms` param to jwt validator