### PR TITLE
JWT middleware: update to handle different source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",
@@ -12,12 +12,14 @@
         "lint": "eslint src --cache",
         "pack:dev": "./scripts/pack-dev.sh",
         "test": "jest",
-        "verify": "yarn lint && yarn test"
+        "verify": "yarn lint && yarn test",
+        "preyalc": "yarn clean && yarn build"
     },
     "dependencies": {
         "apollo-server-express": "^2.9.9",
         "axios": "^0.18.0",
         "connect-requestid": "^1.1.0",
+        "cookie-parser": "^1.4.5",
         "cors": "^2.8.4",
         "dataloader": "^1.4.0",
         "enum": "^2.4.0",

--- a/src/middleware/jwt/__tests__/index.test.js
+++ b/src/middleware/jwt/__tests__/index.test.js
@@ -59,9 +59,9 @@ describe('Configuring the middleware', () => {
         const email = 'first.last@example.com';
         const token = signSymmetric({ email }, secret, audience);
 
-        const response = await request(app).get('/').set(
-            'Authorization', `Bearer ${token}`,
-        );
+        const response = await request(app)
+            .get('/')
+            .set('Authorization', `Bearer ${token}`);
 
         expect(response.statusCode).toBe(404);
         return done();
@@ -72,9 +72,9 @@ describe('Configuring the middleware', () => {
         const key = readFileSync(`${__dirname}/example.key`, 'ascii');
         const token = signPrivate({ email }, key, audience);
 
-        const response = await request(app).get('/').set(
-            'Authorization', `Bearer ${token}`,
-        );
+        const response = await request(app)
+            .get('/')
+            .set('Authorization', `Bearer ${token}`);
 
         expect(response.statusCode).toBe(404);
         return done();

--- a/src/middleware/jwt/__tests__/middleware.test.js
+++ b/src/middleware/jwt/__tests__/middleware.test.js
@@ -153,7 +153,7 @@ describe('JWT middleware', () => {
 
             createValidateJWTMiddleware()(req, res);
         });
-    
+
     });
 
     describe('JWT source: header', () => {

--- a/src/middleware/jwt/__tests__/middleware.test.js
+++ b/src/middleware/jwt/__tests__/middleware.test.js
@@ -20,151 +20,337 @@ describe('JWT middleware', () => {
         res.end = jest.fn(() => null);
     });
 
-    it('requires an audience', () => {
-        const req = {
-            headers: {
-                authorization: 'Bearer token',
-            },
-        };
+    describe('JWT source: default (header)', () => {
 
-        expect(() => createValidateJWTMiddleware()(req)).toThrow(
-            'JWT middleware requires `middleware.jwt.audience` to be configured',
-        );
-    });
-
-    it('validates a token', async (done) => {
-        const email = 'first.last@example.com';
-        const secret = 'secret';
-        const audience = 'audience';
-
-        await Nodule.testing().fromObject({
-            middleware: {
-                jwt: {
-                    audience,
-                    secret,
-                    getToken: req => req.cookies.idToken,
+        it('requires an audience', () => {
+            const req = {
+                headers: {
+                    authorization: 'Bearer token',
                 },
-            },
-        }).load();
+            };
 
-        const token = signSymmetric({ email }, secret, audience);
-        const req = {
-            headers: {
-                authorization: `Bearer ${token}`,
-            },
-            cookies: {
-                idToken: token,
-            },
-        };
-
-        createValidateJWTMiddleware()(req, res, (error) => {
-            expect(error).not.toBeDefined();
-            expect(req.locals.jwt.aud).toEqual(audience);
-            expect(req.locals.jwt.email).toEqual(email);
-            done();
+            expect(() => createValidateJWTMiddleware()(req)).toThrow(
+                'JWT middleware requires `middleware.jwt.audience` to be configured',
+            );
         });
-    });
 
-    it('validates a token with multiple audiences', async (done) => {
-        const email = 'first.last@example.com';
-        const audience = 'test-audience';
-        const audiences = [audience, 'other-audience'];
-        const secret = 'test-secret';
-        await Nodule.testing().fromObject({
-            middleware: {
-                jwt: {
-                    audience: audiences,
-                    secret,
-                    getToken: req => req.cookies.idToken,
+        it('validates a token', async (done) => {
+            const email = 'first.last@example.com';
+            const secret = 'secret';
+            const audience = 'audience';
+
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                    },
                 },
-            },
-        }).load();
+            }).load();
 
-        const token = signSymmetric({ email }, secret, audience);
-        const req = {
-            headers: {
-                authorization: `Bearer ${token}`,
-            },
-            cookies: {
-                idToken: token,
-            },
-        };
+            const token = signSymmetric({ email }, secret, audience);
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
 
-        createValidateJWTMiddleware()(req, res, (error) => {
-            expect(error).not.toBeDefined();
-            expect(req.locals.jwt.aud).toEqual(audience);
-            expect(req.locals.jwt.email).toEqual(email);
-            done();
+            createValidateJWTMiddleware()(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual(audience);
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
         });
-    });
 
-    it('validates a token with multiple audiences as string', async (done) => {
-        const email = 'first.last@example.com';
-        const audience = 'test-audience';
-        const audiences = `${audience},purple-audience`;
-        const secret = 'test-secret';
-        await Nodule.testing().fromObject({
-            middleware: {
-                jwt: {
-                    audience: audiences,
-                    secret,
-                    getToken: req => req.cookies.idToken,
+        it('validates a token with multiple audiences', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const audiences = [audience, 'other-audience'];
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience: audiences,
+                        secret,
+                    },
                 },
-            },
-        }).load();
+            }).load();
 
-        const token = signSymmetric({ email }, secret, 'test-audience');
-        const req = {
-            headers: {
-                authorization: `Bearer ${token}`,
-            },
-            cookies: {
-                idToken: token,
-            },
-        };
+            const token = signSymmetric({ email }, secret, audience);
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
 
-        createValidateJWTMiddleware()(req, res, (error) => {
-            expect(error).not.toBeDefined();
-            expect(req.locals.jwt.aud).toEqual('test-audience');
-            expect(req.locals.jwt.email).toEqual(email);
-            done();
+            createValidateJWTMiddleware()(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual(audience);
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
         });
-    });
 
-
-    it('returns an error on an invalid signature', async (done) => {
-        const email = 'first.last@example.com';
-        const audience = 'test-audience';
-        const secret = 'test-secret';
-        await Nodule.testing().fromObject({
-            middleware: {
-                jwt: {
-                    audience,
-                    secret,
-                    getToken: req => req.cookies.idToken,
+        it('validates a token with multiple audiences as string', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const audiences = `${audience},purple-audience`;
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience: audiences,
+                        secret,
+                    },
                 },
-            },
-        }).load();
+            }).load();
 
-        const token = signSymmetric({ email }, 'wrong', 'audience');
-        const req = {
-            headers: {
-                authorization: `Bearer ${token}`,
-            },
-            cookies: {
-                idToken: token,
-            },
-        };
+            const token = signSymmetric({ email }, secret, 'test-audience');
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
 
-        res.end = () => {
-            expect(res.status).toHaveBeenCalledTimes(1);
-            expect(res.status).toHaveBeenCalledWith(401);
-            expect(res.json).toHaveBeenCalledTimes(1);
-            expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+            createValidateJWTMiddleware()(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual('test-audience');
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
+        });
 
-            return done();
-        };
 
-        createValidateJWTMiddleware()(req, res);
+        it('returns an error on an invalid signature', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, 'wrong', 'audience');
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
+
+            res.end = () => {
+                expect(res.status).toHaveBeenCalledTimes(1);
+                expect(res.status).toHaveBeenCalledWith(401);
+                expect(res.json).toHaveBeenCalledTimes(1);
+                expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+
+                return done();
+            };
+
+            createValidateJWTMiddleware()(req, res);
+        });
+    
     });
+
+    describe('JWT source: header', () => {
+
+        it('validates a token', async (done) => {
+            const email = 'first.last@example.com';
+            const secret = 'secret';
+            const audience = 'audience';
+
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, secret, audience);
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'header' })(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual(audience);
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
+        });
+
+        it('returns an error on an invalid signature', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, 'wrong', 'audience');
+            const req = {
+                headers: {
+                    authorization: `Bearer ${token}`,
+                },
+            };
+
+            res.end = () => {
+                expect(res.status).toHaveBeenCalledTimes(1);
+                expect(res.status).toHaveBeenCalledWith(401);
+                expect(res.json).toHaveBeenCalledTimes(1);
+                expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+
+                return done();
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'header' })(req, res);
+        });
+
+    });
+
+    describe('JWT source: body', () => {
+
+        it('validates a token', async (done) => {
+            const email = 'first.last@example.com';
+            const secret = 'secret';
+            const audience = 'audience';
+
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                        getToken: req => req.body.idToken,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, secret, audience);
+            const req = {
+                body: {
+                    idToken: token,
+                },
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'body' })(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual(audience);
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
+        });
+
+        it('returns an error on an invalid signature', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                        getToken: req => req.body.idToken,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, 'wrong', 'audience');
+            const req = {
+                body: {
+                    idToken: token,
+                },
+            };
+
+            res.end = () => {
+                expect(res.status).toHaveBeenCalledTimes(1);
+                expect(res.status).toHaveBeenCalledWith(401);
+                expect(res.json).toHaveBeenCalledTimes(0);
+
+                return done();
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'body' })(req, res);
+        });
+
+    });
+
+    describe('JWT source: cookie', () => {
+
+        it('validates a token', async (done) => {
+            const email = 'first.last@example.com';
+            const secret = 'secret';
+            const audience = 'audience';
+
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                        getToken: req => req.cookies.idToken,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, secret, audience);
+            const req = {
+                cookies: {
+                    idToken: token,
+                },
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'cookie' })(req, res, (error) => {
+                expect(error).not.toBeDefined();
+                expect(req.locals.jwt.aud).toEqual(audience);
+                expect(req.locals.jwt.email).toEqual(email);
+                done();
+            });
+        });
+
+        it('returns an error on an invalid signature', async (done) => {
+            const email = 'first.last@example.com';
+            const audience = 'test-audience';
+            const secret = 'test-secret';
+            await Nodule.testing().fromObject({
+                middleware: {
+                    jwt: {
+                        audience,
+                        secret,
+                        getToken: req => req.cookies.idToken,
+                    },
+                },
+            }).load();
+
+            const token = signSymmetric({ email }, 'wrong', 'audience');
+            const req = {
+                cookies: {
+                    idToken: token,
+                },
+            };
+
+            res.end = () => {
+                expect(res.status).toHaveBeenCalledTimes(1);
+                expect(res.status).toHaveBeenCalledWith(401);
+                expect(res.json).toHaveBeenCalledTimes(0);
+
+                return done();
+            };
+
+            createValidateJWTMiddleware({ jwtSource: 'cookie' })(req, res);
+        });
+
+    });
+
 });

--- a/src/middleware/jwt/__tests__/middleware.test.js
+++ b/src/middleware/jwt/__tests__/middleware.test.js
@@ -1,7 +1,7 @@
 import { clearBinding, Nodule } from '@globality/nodule-config';
 
 import { signSymmetric } from 'index';
-import middleware from '../middleware';
+import createValidateJWTMiddleware from '../middleware';
 
 
 describe('JWT middleware', () => {
@@ -20,22 +20,6 @@ describe('JWT middleware', () => {
         res.end = jest.fn(() => null);
     });
 
-    it('requires an authorization header', () => {
-        const req = {
-            headers: {
-            },
-        };
-
-        middleware(req, res);
-
-        expect(res.status).toHaveBeenCalledTimes(1);
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledTimes(1);
-        expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
-        expect(res.end).toHaveBeenCalledTimes(1);
-        expect(res.end).toHaveBeenCalledWith();
-    });
-
     it('requires an audience', () => {
         const req = {
             headers: {
@@ -43,7 +27,7 @@ describe('JWT middleware', () => {
             },
         };
 
-        expect(() => middleware(req)).toThrow(
+        expect(() => createValidateJWTMiddleware()(req)).toThrow(
             'JWT middleware requires `middleware.jwt.audience` to be configured',
         );
     });
@@ -58,6 +42,7 @@ describe('JWT middleware', () => {
                 jwt: {
                     audience,
                     secret,
+                    getToken: req => req.cookies.idToken,
                 },
             },
         }).load();
@@ -67,9 +52,12 @@ describe('JWT middleware', () => {
             headers: {
                 authorization: `Bearer ${token}`,
             },
+            cookies: {
+                idToken: token,
+            },
         };
 
-        middleware(req, res, (error) => {
+        createValidateJWTMiddleware()(req, res, (error) => {
             expect(error).not.toBeDefined();
             expect(req.locals.jwt.aud).toEqual(audience);
             expect(req.locals.jwt.email).toEqual(email);
@@ -87,6 +75,7 @@ describe('JWT middleware', () => {
                 jwt: {
                     audience: audiences,
                     secret,
+                    getToken: req => req.cookies.idToken,
                 },
             },
         }).load();
@@ -96,9 +85,12 @@ describe('JWT middleware', () => {
             headers: {
                 authorization: `Bearer ${token}`,
             },
+            cookies: {
+                idToken: token,
+            },
         };
 
-        middleware(req, res, (error) => {
+        createValidateJWTMiddleware()(req, res, (error) => {
             expect(error).not.toBeDefined();
             expect(req.locals.jwt.aud).toEqual(audience);
             expect(req.locals.jwt.email).toEqual(email);
@@ -116,6 +108,7 @@ describe('JWT middleware', () => {
                 jwt: {
                     audience: audiences,
                     secret,
+                    getToken: req => req.cookies.idToken,
                 },
             },
         }).load();
@@ -125,9 +118,12 @@ describe('JWT middleware', () => {
             headers: {
                 authorization: `Bearer ${token}`,
             },
+            cookies: {
+                idToken: token,
+            },
         };
 
-        middleware(req, res, (error) => {
+        createValidateJWTMiddleware()(req, res, (error) => {
             expect(error).not.toBeDefined();
             expect(req.locals.jwt.aud).toEqual('test-audience');
             expect(req.locals.jwt.email).toEqual(email);
@@ -145,6 +141,7 @@ describe('JWT middleware', () => {
                 jwt: {
                     audience,
                     secret,
+                    getToken: req => req.cookies.idToken,
                 },
             },
         }).load();
@@ -153,6 +150,9 @@ describe('JWT middleware', () => {
         const req = {
             headers: {
                 authorization: `Bearer ${token}`,
+            },
+            cookies: {
+                idToken: token,
             },
         };
 
@@ -165,6 +165,6 @@ describe('JWT middleware', () => {
             return done();
         };
 
-        middleware(req, res);
+        createValidateJWTMiddleware()(req, res);
     });
 });

--- a/src/middleware/jwt/index.js
+++ b/src/middleware/jwt/index.js
@@ -1,7 +1,7 @@
 import { bind, setDefaults } from '@globality/nodule-config';
 
 import passBasicAuth from './passBasicAuth';
-import middleware from './middleware';
+import createValidateJWTMiddleware from './middleware';
 
 
 /* Configure JWT-based authorization as a middleware.
@@ -26,8 +26,13 @@ setDefaults('middleware.jwt', {
     /* A basic auth realm to generate WWW-Authenticate headers for.
      */
     realm: null,
+
+
 });
 
 
 bind('middleware.passBasicAuth', () => passBasicAuth);
-bind('middleware.jwt', () => middleware);
+bind('middleware.jwt', () => createValidateJWTMiddleware({ jwtSource: 'header' }));
+bind('middleware.jwtBody', () => createValidateJWTMiddleware({ jwtSource: 'body' }));
+bind('middleware.jwtCookie', () => createValidateJWTMiddleware({ jwtSource: 'cookie' }));
+bind('middleware.jwtHeader', () => createValidateJWTMiddleware({ jwtSource: 'header' }));

--- a/src/middleware/jwt/middleware.js
+++ b/src/middleware/jwt/middleware.js
@@ -1,5 +1,6 @@
 import jwt from 'express-jwt';
 import { get } from 'lodash';
+import { UNAUTHORIZED } from 'http-status-codes';
 
 import { getConfig, getMetadata, getContainer } from '@globality/nodule-config';
 
@@ -7,7 +8,7 @@ import sendUnauthorized from './errors';
 import negotiateKey from './negotiate';
 
 
-function chooseAudience(audience) {
+export function chooseAudience(audience) {
     if (!audience) {
         const metadata = getMetadata();
         if (!metadata || !metadata.testing) {
@@ -29,35 +30,68 @@ function chooseAudience(audience) {
 }
 
 
-export default function middleware(req, res, next) {
-    const config = getConfig('middleware.jwt') || {};
-    const { audience, realm } = config;
+export default function createValidateJWTMiddleware (options = { jwtSource: 'header' }) {
+    const { jwtSource } = options;
 
-    if (!req.headers.authorization) {
-        return sendUnauthorized(req, res, realm);
-    }
+    return function middleware (req, res, next) {
+        const config = getConfig('middleware.jwt') || {};
+        const { audience, realm } = config;
+        const matchingAudience = chooseAudience(audience);
 
-    const matchingAudience = chooseAudience(audience);
+        const algorithms = get(config, 'algorithms', 'HS256,RS256').split(',').filter(
+            algorithm => !!algorithm,
+        ).map(
+            algorithm => algorithm.trim(),
+        );
 
-    const algorithms = get(config, 'algorithms', 'HS256,RS256').split(',').filter(
-        algorithm => !!algorithm,
-    ).map(
-        algorithm => algorithm.trim(),
-    );
+        const jwtOptions = {
+            secret: negotiateKey,
+            audience: matchingAudience,
+            requestProperty: 'locals.jwt',
+            algorithms,
+        };
 
-    const validator = jwt({
-        secret: negotiateKey,
-        audience: matchingAudience,
-        requestProperty: 'locals.jwt',
-        algorithms,
-    });
-
-    return validator(req, res, (error) => {
-        if (error) {
-            const { logger } = getContainer();
-            logger.info(req, `jwt validation failed: ${error.message}`, error);
-            return sendUnauthorized(req, res, realm);
+        switch (jwtSource) {
+            case 'body':
+                if (!req.body.idToken) {
+                    return res.status(UNAUTHORIZED).end();
+                }
+                jwtOptions.getToken = request => request.body.idToken;
+                break;
+            case 'cookie':
+                if (!req.cookies.idToken) {
+                    return res.status(UNAUTHORIZED).end();
+                }
+                jwtOptions.getToken = request => request.cookies.idToken;
+                break;
+            case 'header':
+                if (!req.headers.authorization) {
+                    return sendUnauthorized(req, res, realm);
+                }
+                break;
+            default:
+                throw new Error('invalid JWT source');
         }
-        return next();
-    });
+
+        const validator = jwt(jwtOptions);
+
+        return validator(req, res, (error) => {
+            if (error) {
+                const { logger } = getContainer();
+                logger.info(req, `jwt validation failed: ${error.message}`, error);
+
+                switch (jwtSource) {
+                    case 'cookie':
+                        return res.status(UNAUTHORIZED).end();
+                    case 'body':
+                        return res.status(UNAUTHORIZED).end();
+                    case 'header':
+                        return sendUnauthorized(req, res, realm);
+                    default:
+                        throw new Error('invalid JWT source');
+                }
+            }
+            return next();
+        });
+    };
 }

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -209,8 +209,6 @@ bind('routes.graphql', () => {
     const { terminal } = getContainer();
     const options = createApolloServerOptions();
     const server = new ApolloServer(options);
-
     terminal.enabled('graphql');
-
-    return server.getMiddleware();
+    return server.getMiddleware({ cors: false });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,6 +2165,14 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
+  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
updated create JWT middleware to take JWT token from different sources: body, cookie and header.

`middleware.jwt` used default jwt source (header) to avoid breaking changes.

Related to https://globality.atlassian.net/browse/GLOB-45370