### PR TITLE
Release 1.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,8 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.6.0
 commit = False
 tag = False
 
 [bumpversion:file:package.json]
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.5.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",


### PR DESCRIPTION
Bump version for release.

Minor version because we've changed a lot of dependencies: this feels a bit too big for a patch.