### PR TITLE
GLOB-51227: add ability to set up apollo plugins

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0
+current_version = 1.6.1
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.2
+current_version = 1.7.0
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+### v1.6.1
+
+- Added ability to set `routes.graphql.apolloPlugins` config. Used to configure Apollo plugins that allow to customize response to events regarding startup apollo server startup and phases of a GraphQL request ([read more about Apollo Server plugins](https://www.apollographql.com/docs/apollo-server/integrations/plugins)).
+
 ### v1.1.0
 
 [See complete versioning details.](https://github.com/globality-corp/nodule-graphql/commit/349863d94834a12ab2b6df6c4b1a837560d6c00e)
 
 - Added `routes.graphql.apolloEngine` config. Used to configure Apollo engine used by the Apollo Server instances that drives the graphql route.
-- `tracing` and `cacheControl` graphql route config options are now deprecatd. They are only intended for the now deprecated Apollo engine proxy. Config options will eventually
+- `tracing` and `cacheControl` graphql route config options are now deprecated. They are only intended for the now deprecated Apollo engine proxy. Config options will eventually
 be removed.
 
 ### v1.0.0
@@ -16,6 +20,6 @@ be removed.
 
 [See complete versioning details.](https://github.com/globality-corp/nodule-graphql/commit/e8d251f39d0263e495cae8c99e86179808584019)
 
-- Upgrade `apollo-server` depedency. Now using v2.
-- Upgrade `graphql` depencency. Now using v14.
+- Upgrade `apollo-server` dependency. Now using v2.
+- Upgrade `graphql` dependency. Now using v14.
 - `routes.graphiql` now uses [graphql playground](https://github.com/prisma-labs/graphql-playground) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v1.6.1
+### v1.7.0
 
 - Added ability to set `routes.graphql.apolloPlugins` config. Used to configure Apollo plugins that allow to customize response to events regarding startup apollo server startup and phases of a GraphQL request ([read more about Apollo Server plugins](https://www.apollographql.com/docs/apollo-server/integrations/plugins)).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -66,31 +66,4 @@ describe('routes.graphql', () => {
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', []);
     });
 
-    // it('will supply apollo plugins configs to apollo server instance', async () => {
-    //     var mockApolloServer = jest.fn();
-    //     apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
-
-    //     setDefaults('routes.graphql.apolloPlugins', {
-    //         requestDidStart(_) {
-    //           return {
-    //             didEncounterErrors(ctx) {
-    //               console.log('Server starting up!');
-    //             }
-    //           };
-    //         }
-    //     });
-
-    //     await Nodule.testing().load();
-
-    //     getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
-
-    //     console.log(mockApolloServer.mock);
-    //     expect(mockApolloServer.mock.calls).toHaveLength(1);
-    //     expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
-    //     expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
-    //             requestDidStart: expect.any(Function)
-    //         },
-    //     );
-    //     // console.log(mockApolloServer.mock.calls[0][0]);
-    // });
 });

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -31,22 +31,6 @@ bind('graphql.schema', () => schema);
 
 describe('routes.graphql', () => {
 
-
-    beforeEach(() => {
-        clearBinding('mockApolloServer');
-        // clearBinding('config');
-    });
-
-    afterEach(() => {
-        // jest.clearAllMocks();
-        // mockApolloServer.mockClear();
-        jest.restoreAllMocks()
-        apolloServerExpress.ApolloServer.mockRestore();
-        clearBinding('mockApolloServer');
-        clearBinding('apolloServerExpress.ApolloServer');
-
-    });
-
     it('will supply apollo engine configs to apollo server instance', async () => {
         var mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
@@ -84,31 +68,31 @@ describe('routes.graphql', () => {
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', undefined);
     });
 
-    it('will supply apollo plugins configs to apollo server instance', async () => {
-        var mockApolloServer = jest.fn();
-        apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
+    // it('will supply apollo plugins configs to apollo server instance', async () => {
+    //     var mockApolloServer = jest.fn();
+    //     apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
-        setDefaults('routes.graphql.apolloPlugins', {
-            requestDidStart(_) {
-              return {
-                didEncounterErrors(ctx) {
-                  console.log('Server starting up!');
-                }
-              };
-            }
-        });
+    //     setDefaults('routes.graphql.apolloPlugins', {
+    //         requestDidStart(_) {
+    //           return {
+    //             didEncounterErrors(ctx) {
+    //               console.log('Server starting up!');
+    //             }
+    //           };
+    //         }
+    //     });
 
-        await Nodule.testing().load();
+    //     await Nodule.testing().load();
 
-        getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
+    //     getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
 
-        console.log(mockApolloServer.mock);
-        expect(mockApolloServer.mock.calls).toHaveLength(1);
-        expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
-        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
-                requestDidStart: expect.any(Function)
-            },
-        );
-        // console.log(mockApolloServer.mock.calls[0][0]);
-    });
+    //     console.log(mockApolloServer.mock);
+    //     expect(mockApolloServer.mock.calls).toHaveLength(1);
+    //     expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
+    //     expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
+    //             requestDidStart: expect.any(Function)
+    //         },
+    //     );
+    //     // console.log(mockApolloServer.mock.calls[0][0]);
+    // });
 });

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -63,7 +63,7 @@ describe('routes.graphql', () => {
                 onlyNames: ['x-mock-header'],
             },
         }));
-        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', undefined);
+        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', []);
     });
 
     // it('will supply apollo plugins configs to apollo server instance', async () => {

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -4,7 +4,7 @@ import {
     GraphQLSchema,
 } from 'graphql';
 
-import { bind, setDefaults, getContainer, clearBinding, Nodule } from '@globality/nodule-config';
+import { bind, setDefaults, getContainer, Nodule } from '@globality/nodule-config';
 
 jest.mock('apollo-server-express');
 
@@ -32,7 +32,7 @@ bind('graphql.schema', () => schema);
 describe('routes.graphql', () => {
 
     it('will supply apollo engine configs to apollo server instance', async () => {
-        var mockApolloServer = jest.fn();
+        const mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
         setDefaults('routes.graphql.apolloEngine', {
@@ -50,9 +50,7 @@ describe('routes.graphql', () => {
         await Nodule.testing().load();
 
         getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
-        
-        console.log(mockApolloServer.mock);
-        // console.log(mockApolloServer.mock.calls);
+
         expect(mockApolloServer.mock.calls).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('engine', expect.objectContaining({

--- a/src/routes/__tests__/graphql.test.js
+++ b/src/routes/__tests__/graphql.test.js
@@ -33,15 +33,22 @@ describe('routes.graphql', () => {
 
 
     beforeEach(() => {
-        // clearBinding('mockApolloServer');
+        clearBinding('mockApolloServer');
+        // clearBinding('config');
     });
 
     afterEach(() => {
-        jest.clearAllMocks();
+        // jest.clearAllMocks();
+        // mockApolloServer.mockClear();
+        jest.restoreAllMocks()
+        apolloServerExpress.ApolloServer.mockRestore();
+        clearBinding('mockApolloServer');
+        clearBinding('apolloServerExpress.ApolloServer');
+
     });
 
     it('will supply apollo engine configs to apollo server instance', async () => {
-        const mockApolloServer = jest.fn();
+        var mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
         setDefaults('routes.graphql.apolloEngine', {
@@ -60,7 +67,8 @@ describe('routes.graphql', () => {
 
         getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
         
-        console.log(mockApolloServer.mock.calls);
+        console.log(mockApolloServer.mock);
+        // console.log(mockApolloServer.mock.calls);
         expect(mockApolloServer.mock.calls).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('engine', expect.objectContaining({
@@ -77,7 +85,7 @@ describe('routes.graphql', () => {
     });
 
     it('will supply apollo plugins configs to apollo server instance', async () => {
-        const mockApolloServer = jest.fn();
+        var mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
         setDefaults('routes.graphql.apolloPlugins', {
@@ -88,19 +96,19 @@ describe('routes.graphql', () => {
                 }
               };
             }
-          });
+        });
 
         await Nodule.testing().load();
 
         getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
 
-        console.log(mockApolloServer.mock.calls);
+        console.log(mockApolloServer.mock);
         expect(mockApolloServer.mock.calls).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
                 requestDidStart: expect.any(Function)
             },
         );
-        console.log(mockApolloServer.mock.calls[0][0]);
+        // console.log(mockApolloServer.mock.calls[0][0]);
     });
 });

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -36,13 +36,9 @@ describe('routes.graphql', () => {
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
         setDefaults('routes.graphql.apolloPlugins', {
-            requestDidStart() {
-                return {
-                    didEncounterErrors() {
-                        console.log('didEncounterErrors');
-                    },
-                };
-            },
+            requestDidStart: () => ({
+                didEncounterErrors: () => null,
+            }),
         });
 
         await Nodule.testing().load();

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -35,11 +35,11 @@ describe('routes.graphql', () => {
         const mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
-        setDefaults('routes.graphql.apolloPlugins', {
+        setDefaults('routes.graphql.apolloPlugins', [{
             requestDidStart: () => ({
                 didEncounterErrors: () => null,
             }),
-        });
+        }]);
 
         await Nodule.testing().load();
 

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -4,7 +4,7 @@ import {
     GraphQLSchema,
 } from 'graphql';
 
-import { bind, setDefaults, getContainer, clearBinding, Nodule } from '@globality/nodule-config';
+import { bind, setDefaults, getContainer, Nodule } from '@globality/nodule-config';
 
 jest.mock('apollo-server-express');
 
@@ -32,17 +32,18 @@ bind('graphql.schema', () => schema);
 describe('routes.graphql', () => {
 
     it('will supply apollo plugins configs to apollo server instance', async () => {
-        var mockApolloServer = jest.fn();
+        const mockApolloServer = jest.fn();
         apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
 
         setDefaults('routes.graphql.apolloPlugins', {
-            requestDidStart(_) {
-              return {
-                didEncounterErrors(ctx) {
-                  console.log('Server starting up!');
-                }
-              };
-            }
+            requestDidStart() {
+                return {
+                    didEncounterErrors(ctx) {
+                        console.log('Server starting up!');
+                        console.log(ctx);
+                    },
+                };
+            },
         });
 
         await Nodule.testing().load();
@@ -52,8 +53,7 @@ describe('routes.graphql', () => {
         expect(mockApolloServer.mock.calls).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
-                requestDidStart: expect.any(Function)
-            },
-        );
+            requestDidStart: expect.any(Function),
+        });
     });
 });

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -38,13 +38,12 @@ describe('routes.graphql', () => {
         setDefaults('routes.graphql.apolloPlugins', {
             requestDidStart() {
                 return {
-                    didEncounterErrors(ctx) {
-                        console.log('Server starting up!');
-                        console.log(ctx);
+                    didEncounterErrors() {
+                        console.log('didEncounterErrors')
                     },
                 };
             },
-        });
+          });
 
         await Nodule.testing().load();
 
@@ -52,8 +51,8 @@ describe('routes.graphql', () => {
 
         expect(mockApolloServer.mock.calls).toHaveLength(1);
         expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
-        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
+        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', [{
             requestDidStart: expect.any(Function),
-        });
+        }]);
     });
 });

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -1,0 +1,59 @@
+import {
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLSchema,
+} from 'graphql';
+
+import { bind, setDefaults, getContainer, clearBinding, Nodule } from '@globality/nodule-config';
+
+jest.mock('apollo-server-express');
+
+import * as apolloServerExpress from 'apollo-server-express'; // eslint-disable-line import/first
+import '../graphql'; // eslint-disable-line import/first
+import '../../terminal'; // eslint-disable-line import/first
+
+const QueryType = new GraphQLObjectType({
+    name: 'QueryType',
+    description: 'Top-level queries',
+    fields: {
+        hello: {
+            type: GraphQLString,
+            resolve: () => 'world',
+        },
+    },
+});
+
+const schema = new GraphQLSchema({
+    query: QueryType,
+});
+
+bind('graphql.schema', () => schema);
+
+describe('routes.graphql', () => {
+
+    it('will supply apollo plugins configs to apollo server instance', async () => {
+        var mockApolloServer = jest.fn();
+        apolloServerExpress.ApolloServer.mockImplementation(mockApolloServer.mockReturnThis());
+
+        setDefaults('routes.graphql.apolloPlugins', {
+            requestDidStart(_) {
+              return {
+                didEncounterErrors(ctx) {
+                  console.log('Server starting up!');
+                }
+              };
+            }
+        });
+
+        await Nodule.testing().load();
+
+        getContainer('routes').graphql; // eslint-disable-line no-unused-expressions
+
+        expect(mockApolloServer.mock.calls).toHaveLength(1);
+        expect(mockApolloServer.mock.calls[0]).toHaveLength(1);
+        expect(mockApolloServer.mock.calls[0][0]).toHaveProperty('plugins', {
+                requestDidStart: expect.any(Function)
+            },
+        );
+    });
+});

--- a/src/routes/__tests__/graphqlApolloPlugins.test.js
+++ b/src/routes/__tests__/graphqlApolloPlugins.test.js
@@ -39,11 +39,11 @@ describe('routes.graphql', () => {
             requestDidStart() {
                 return {
                     didEncounterErrors() {
-                        console.log('didEncounterErrors')
+                        console.log('didEncounterErrors');
                     },
                 };
             },
-          });
+        });
 
         await Nodule.testing().load();
 

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -110,6 +110,11 @@ function formatError(error) {
     return newError;
 }
 
+/**
+ * Creates apollo server initialization options.
+ * 
+ * Allows to configure apollo engine options and plugins.
+ */
 function createApolloServerOptions() {
     const { config, graphql } = getContainer();
     const { schema } = graphql;

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -138,9 +138,7 @@ function createApolloServerOptions() {
         rootValue: null,
         schema,
         engine: engineEnabled ? engineConfig : false,
-        plugins: [
-            apolloPlugins,
-        ] ? apolloPlugins : null,
+        plugins: apolloPlugins ? [apolloPlugins] : null,
     };
 }
 

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -123,7 +123,8 @@ function createApolloServerOptions() {
         global.console.warn('DEPRECATED: config.routes.graphql.tracing. No longer used');
     }
 
-    const { apolloEngine } = config.routes.graphql;
+    const { apolloEngine, apolloPlugins } = config.routes.graphql;
+
     const {
         enabled: engineEnabled,
         ...engineConfig
@@ -137,6 +138,9 @@ function createApolloServerOptions() {
         rootValue: null,
         schema,
         engine: engineEnabled ? engineConfig : false,
+        plugins: [
+            apolloPlugins
+        ] ? apolloPlugins : null,
     };
 }
 

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -139,7 +139,7 @@ function createApolloServerOptions() {
         schema,
         engine: engineEnabled ? engineConfig : false,
         plugins: [
-            apolloPlugins
+            apolloPlugins,
         ] ? apolloPlugins : null,
     };
 }

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -138,7 +138,7 @@ function createApolloServerOptions() {
         rootValue: null,
         schema,
         engine: engineEnabled ? engineConfig : false,
-        plugins: apolloPlugins ? [apolloPlugins] : null,
+        plugins: apolloPlugins ? [apolloPlugins] : [],
     };
 }
 

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -143,7 +143,7 @@ function createApolloServerOptions() {
         rootValue: null,
         schema,
         engine: engineEnabled ? engineConfig : false,
-        plugins: apolloPlugins ? [apolloPlugins] : [],
+        plugins: apolloPlugins ?? [],
     };
 }
 

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -120,7 +120,7 @@ function createApolloServerOptions() {
     }
 
     if (graphqlConfig.cacheControl) {
-        global.console.warn('DEPRECATED: config.routes.graphql.tracing. No longer used');
+        global.console.warn('DEPRECATED: config.routes.graphql.cacheControl. No longer used');
     }
 
     const { apolloEngine, apolloPlugins } = config.routes.graphql;

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -112,7 +112,7 @@ function formatError(error) {
 
 /**
  * Creates apollo server initialization options.
- * 
+ *
  * Allows to configure apollo engine options and plugins.
  */
 function createApolloServerOptions() {
@@ -143,7 +143,7 @@ function createApolloServerOptions() {
         rootValue: null,
         schema,
         engine: engineEnabled ? engineConfig : false,
-        plugins: apolloPlugins ?? [],
+        plugins: apolloPlugins || [],
     };
 }
 


### PR DESCRIPTION
Add ability to set up apollo plugins

Fixes [GLOB-51227]

## Why

I need to enable apollo server to receive configuration for plugins, so that I can setup plugins on our gateways. A use case for this is setting sentry support (read https://blog.sentry.io/2020/07/22/handling-graphql-errors-using-sentry).

## What

- Add ability for the apollo server to receive plugins configuration from downstream modules. This should be optional, so if not provided the value should behave properly as before.

## Test

```
yarn test src/routes/__tests__/graphqlApolloPlugins.test.js
```

or

```
yarn test
```

## References

- https://www.apollographql.com/docs/apollo-server/monitoring/metrics/
- https://blog.sentry.io/2020/07/22/handling-graphql-errors-using-sentry
- https://www.apollographql.com/docs/apollo-server/integrations/plugins/

[GLOB-51227]: https://globality.atlassian.net/browse/GLOB-51227