### PR TITLE
Fix bug in raising error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/services/core/named.js
+++ b/src/services/core/named.js
@@ -9,6 +9,6 @@ export default function named(serviceRequestName) {
     const clients = getContainer(clientsName || 'clients');
     return (req, args) =>
         get(clients, `${serviceRequestName}`, () => {
-            throw InternalServerError(`${serviceRequestName} not implemented`);
+            throw new InternalServerError(`${serviceRequestName} not implemented`);
         })(req, args);
 }


### PR DESCRIPTION
Before:
```
Received: [{"extensions": {"code": "INTERNAL_SERVER_ERROR"}, "locations": [{"column": 19, "line": 10}], "message": "Class constructor InternalServerError cannot be invoked without 'new'", "path": ["workspace", "items", 0, "taskOrderTemplate", "file", "boxToken"]}]
```


After
```
 Received: [{"extensions": {"code": "HTTP-500"}, "locations": [{"column": 19, "line": 10}], "message": "crespi.boxTokens.retrieveFor.platformCompany not implemented", "path": ["workspace", "items", 0, "taskOrderTemplate", "file", "boxToken"]}]
```

tested using Styx unit tests and locally linked package.