### PR TITLE
GLOB-76146: Support passing the options argument to operation requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -11,7 +11,7 @@ export { ANY_NOT_NULL, ANY_PARAMETER, ANY_SINGLE_ITEM_LIST, ANY_UUID, CachingSpe
 export function cloneClients(obj) {
     return cloneDeepWith(obj, (node) =>
         typeof node === 'function'
-            ? async (req, args) => node(req, args)
+            ? async (req, args, options) => node(req, args, options)
             : Object.keys(node).reduce((acc, key) => ({ ...acc, [key]: cloneClients(node[key]) }), {})
     );
 }


### PR DESCRIPTION
## What

This PR updates the `cloneClients` function to support the `options` argument for each operation.

## Why

To allow consumers to pass the `options` argument containing properties such as `additionalHeaders` when making requests to services e.g. `sphinx.moderationEvents.create(req, args, options)`.

Currently, such options are ignored as they are not passed here.