### PR TITLE
Added preAggregate

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 2.1.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/resolvers.js
+++ b/src/__tests__/resolvers.js
@@ -12,6 +12,7 @@ const retrieveCompanyName = createResolver({
 });
 
 const retrieveUser = createResolver({
+    preAggregate: () => {},
     aggregate: ({ userId }) => {
         const { services } = getContainer();
         return services.user.retrieve(userId);


### PR DESCRIPTION
**Why?**
Sometimes, we may like to do some preparations involving a network call, before a resolver's aggregate function is called.


**What?**
Added the `preAggregate` hook that uses the same arguments that the `aggregate` and can make network requests.