### PR TITLE
Added overfetching guard to resolver class

### DIFF
--- a/src/resolvers/__tests__/resolver.test.js
+++ b/src/resolvers/__tests__/resolver.test.js
@@ -123,9 +123,7 @@ describe('a resolver', () => {
             maxCallsPerRequest: 1,
         });
         expect(await resolver.resolve(undefined, undefined, context)).toEqual(42);
-        await expect(resolver.resolve(undefined, undefined, context)).rejects.toThrow(
-            'Exceeded maximum number of resolver calls per request: 1, called 2 times.'
-        );
+        expect(await resolver.resolve(undefined, undefined, context)).toEqual(42);
         expect(context.callCounts[resolver.resolverId]).toEqual(2);
     });
 });

--- a/src/resolvers/__tests__/resolver.test.js
+++ b/src/resolvers/__tests__/resolver.test.js
@@ -76,4 +76,56 @@ describe('a resolver', () => {
         });
         expect(await resolver.resolve()).toEqual(42);
     });
+
+    it('maxCallsPerRequest not used when context not passed', async () => {
+        const resolver = createResolver({
+            aggregate: async () => 42,
+            mask: () => [],
+            maxCallsPerRequest: 0,
+        });
+        expect(await resolver.resolve()).toEqual(42);
+    });
+
+    it('maxCallsPerRequest not used when not directly enabled', async () => {
+        const context = {};
+        const resolver = createResolver({
+            aggregate: async () => 42,
+            mask: () => [],
+        });
+        expect(await resolver.resolve(undefined, undefined, context)).toEqual(42);
+        expect(context.callCounts).toBeUndefined();
+    });
+
+    it('maxCallsPerRequest sets call counts in the context using resolver id', async () => {
+        const context = {};
+        const resolverA = createResolver({
+            aggregate: async () => 42,
+            mask: () => [],
+            maxCallsPerRequest: 1,
+        });
+        const resolverB = createResolver({
+            aggregate: async () => 34,
+            mask: () => [],
+            maxCallsPerRequest: 1,
+        });
+        expect(await resolverA.resolve(undefined, undefined, context)).toEqual(42);
+        expect(await resolverB.resolve(undefined, undefined, context)).toEqual(34);
+        expect(context.callCounts[resolverA.resolverId]).toEqual(1);
+        expect(context.callCounts[resolverB.resolverId]).toEqual(1);
+        expect(resolverA.resolverId === resolverB.resolverId).toBeFalsy();
+    });
+
+    it('maxCallsPerRequest triggers error when exceeded', async () => {
+        const context = {};
+        const resolver = createResolver({
+            aggregate: async () => 42,
+            mask: () => [],
+            maxCallsPerRequest: 1,
+        });
+        expect(await resolver.resolve(undefined, undefined, context)).toEqual(42);
+        await expect(resolver.resolve(undefined, undefined, context)).rejects.toThrow(
+            'Exceeded maximum number of resolver calls per request: 1, called 2 times.'
+        );
+        expect(context.callCounts[resolver.resolverId]).toEqual(2);
+    });
 });

--- a/src/resolvers/types.js
+++ b/src/resolvers/types.js
@@ -9,26 +9,26 @@ function defaultMask(obj, args, context, info) {
     return [obj, args, context, info];
 }
 
-/**
- * A resolver is a structured abstraction around a GraphQL resolver function.
- *
- * @param {Object} options
- * @param {Function} options.aggregate An async function, which queries/mutates data from one or more services.
- * @param {Function} options.authorize An async function, which throws an error if the resolver should not run.
- * @param {Function} options.authorizeData A user-defined payload, which is passed to the `authorize` function
- * (if provided).
- * @param {Function} options.transform A synchronous function, which presents the result of the aggregation in
- * the expected shape of the upstream resource.
- * @param {Function} options.mask A synchronous function, which manipulates the standard GraphQL resolver arguments
- * into a form supported by the other functions.
- * @param {Function} options.preAggregate An async function, which can be used to factor out some preliminary work,
- * that requires a network call. It can alter the arguments passed to the `aggregate` function, but can't change their order.
- * Note it gets arguments in the order they are returned by `mask`.
- * @param {Number} options.maxCallsPerRequest An integer, which specifies the number of times the resolver can be called
- * within a single request. More calls will rsult in logging a warning, that can be used for alerting. This is to prevent
- * overfetching by API clients, when it's known that a given resolver should be triggered only once, for a single parent object.
- */
 export class Resolver {
+    /**
+     * A resolver is a structured abstraction around a GraphQL resolver function.
+     *
+     * @param {Object} options
+     * @param {Function} options.aggregate An async function, which queries/mutates data from one or more services.
+     * @param {Function} options.authorize An async function, which throws an error if the resolver should not run.
+     * @param {Function} options.authorizeData A user-defined payload, which is passed to the `authorize` function
+     * (if provided).
+     * @param {Function} options.transform A synchronous function, which presents the result of the aggregation in
+     * the expected shape of the upstream resource.
+     * @param {Function} options.mask A synchronous function, which manipulates the standard GraphQL resolver arguments
+     * into a form supported by the other functions.
+     * @param {Function} options.preAggregate An async function, which can be used to factor out some preliminary work,
+     * that requires a network call. It can alter the arguments passed to the `aggregate` function, but can't change their order.
+     * Note it gets arguments in the order they are returned by `mask`.
+     * @param {Number} options.maxCallsPerRequest An integer, which specifies the number of times the resolver can be called
+     * within a single request. More calls will rsult in logging a warning, that can be used for alerting. This is to prevent
+     * overfetching by API clients, when it's known that a given resolver should be triggered only once, for a single parent object.
+     */
     constructor({ aggregate, authorize, authorizeData, transform, mask, preAggregate, maxCallsPerRequest }) {
         this.aggregate = aggregate;
         this.authorize = authorize;

--- a/src/resolvers/types.js
+++ b/src/resolvers/types.js
@@ -12,22 +12,21 @@ function defaultMask(obj, args, context, info) {
 /**
  * A resolver is a structured abstraction around a GraphQL resolver function.
  *
- * It includes:
- *
- *  -  An async `aggregate` function, which queries/mutates data from one or more services.
- *  -  An async `authorize` function, which throws an error if the resolver should not run.
- *  -  A user-defined `authorizedData` payload, which is passed to the `authorize` function
- *     (if provided).
- *  -  A synchronous `transform` function, which presents the result of the aggregation in
- *     the expected shape of the upstream resource.
- *  -  A synchronous `mask` function, which manipulates the standard GraphQL resolver
- *     arguments into a form supported by the other functions.
- *  -  An async `preAggregate` function, which can be used to factor out some preliminary work,
- *     that requires a network call. It can alter the arguments passed to the `aggregate` function,
- *     but can't change their order. Note it gets arguments in the order they are returned by `mask`.
- *  -  A `maxCallsPerRequest` integer, which limits the number of times the resolver can be called
- *     within a single request. This is to prevent overfetching by API clients, when it's known that
- *     given resolver should be triggered only once, for a single parent object.
+ * @param {Object} options
+ * @param {Function} options.aggregate An async function, which queries/mutates data from one or more services.
+ * @param {Function} options.authorize An async function, which throws an error if the resolver should not run.
+ * @param {Function} options.authorizeData A user-defined payload, which is passed to the `authorize` function
+ * (if provided).
+ * @param {Function} options.transform A synchronous function, which presents the result of the aggregation in
+ * the expected shape of the upstream resource.
+ * @param {Function} options.mask A synchronous function, which manipulates the standard GraphQL resolver arguments
+ * into a form supported by the other functions.
+ * @param {Function} options.preAggregate An async function, which can be used to factor out some preliminary work,
+ * that requires a network call. It can alter the arguments passed to the `aggregate` function, but can't change their order.
+ * Note it gets arguments in the order they are returned by `mask`.
+ * @param {Number} options.maxCallsPerRequest An integer, which specifies the number of times the resolver can be called
+ * within a single request. More calls will rsult in logging a warning, that can be used for alerting. This is to prevent
+ * overfetching by API clients, when it's known that a given resolver should be triggered only once, for a single parent object.
  */
 export class Resolver {
     constructor({ aggregate, authorize, authorizeData, transform, mask, preAggregate, maxCallsPerRequest }) {
@@ -53,9 +52,9 @@ export class Resolver {
             }
             const callCount = ++context.callCounts[this.resolverId]; // eslint-disable-line no-plusplus
             if (callCount > this.maxCallsPerRequest) {
-                throw new Error(
-                    `Exceeded maximum number of resolver calls per request: ${this.maxCallsPerRequest}, called ${callCount} times.`
-                );
+                const { logger } = getContainer();
+                const msg = `Exceeded maximum number of resolver calls per request: ${this.maxCallsPerRequest}, called ${callCount} times.`;
+                logger.warning(context, msg);
             }
         }
 


### PR DESCRIPTION
## Why?

Usually, to avoid N+1 problem, we use batching configurations. However, there are cases where number of items we fetch is too big even when batching is enabled.

See this example query:
```
query projects {
    projects {
        id
        name
        proposals {
            id
            versions {
               id
            }
        }
    }
}
```

In reality, we most likely don't need to fetch all proposal versions at the same time when we fetch projects and even with proper batching, we might be fetching thousands of proposal versions. Instead, we should  take advantage of app navigation and break this down into e.g.:
```
query projects {
    projects {
        id
        name
    }
}
```

```
query projectProposals($projectId: ID!) {
    projects(projectId: $projectId) {
        id
        name
        proposals {
            id
        }
    }
}
```

```
query projectProposalVersions($projectId: ID!, $proposalID: ID!) {
    projects(projectId: $projectId) {
        id
        name
        proposals(proposalID: $proposalID) {
            id
            versions {
               id
            }
        }
    }
}
```

Right now, we don't have any way to enforce breaking such queries. This PR aims to add a configurable mechanism to resolvers, which will lead to raising an error when a resolver is subject to N+1 problem.

Solution proposed here would act as an implementation tip, for FE devs to define queries with a proper scope (how many nested objects they get in one go).


## What?

-  resolver can be configured using optional `maxCallsPerRequest` integer, which limits the number of times the resolver can be called within a single request.