### PR TITLE
disable introspection in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -136,6 +136,7 @@ function createApolloServerOptions() {
         formatError,
         formatResponse: injectExtensions,
         rootValue: null,
+        introspection: process.env.NODE_ENV !== 'production',
         schema,
         apollo: {
             key: apiKey,


### PR DESCRIPTION
flagged as a security risk, disable in production. looks like it might be used in some scripts, so don't think we can just disable completely. 