### PR TITLE
GLOB-76267 - disable introspection for styx prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-graphql",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "description": "Node GraphQL Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/routes/graphql.js
+++ b/src/routes/graphql.js
@@ -136,6 +136,8 @@ function createApolloServerOptions() {
         formatError,
         formatResponse: injectExtensions,
         rootValue: null,
+        // disable introspection for production styx environments
+        introspection: process.env.STYX__ENVIRONMENT !== 'prod' && process.env.STYX__ENVIRONMENT !== 'prod_eu',
         schema,
         apollo: {
             key: apiKey,


### PR DESCRIPTION
this is a forward port of https://github.com/globality-corp/nodule-graphql/commit/5ef6ccb3b6a37a9be33e64bca91012a94f9e0cde since styx is using v2

disables introspection for production styx (flagged as a security risk)