### PR TITLE
Add request context

### DIFF
--- a/src/resolvers/context.js
+++ b/src/resolvers/context.js
@@ -1,1 +1,3 @@
+const { AsyncLocalStorage } = require('node:async_hooks');
+
 export const requestContext = new AsyncLocalStorage();

--- a/src/resolvers/context.js
+++ b/src/resolvers/context.js
@@ -1,0 +1,1 @@
+export const requestContext = new AsyncLocalStorage();

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,4 +1,5 @@
 import './null';
 
+export { requestContext } from './context';
 export { getResolver, getResolverPipeline } from './pipeline';
 export { createResolver, createStrictResolver } from './types';

--- a/src/resolvers/types.js
+++ b/src/resolvers/types.js
@@ -2,6 +2,8 @@ import { getContainer } from '@globality/nodule-config';
 import { isFunction, isNil } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
+import { requestContext } from './context'
+
 /**
  * Default mask function: preserves standard arguments
  */
@@ -79,8 +81,7 @@ export class Resolver {
         }
 
         // aggregate asynchronous requests over services.
-        const aggregated = await this.aggregate(...masked);
-
+        const aggregated = await requestContext.run(context, () => this.aggregate(...masked));
         if (!this.transform) {
             return aggregated;
         }


### PR DESCRIPTION
We should have the request context available in the resolvers without passing through the context in code 